### PR TITLE
Development-time dependencies and exec support

### DIFF
--- a/cli/src/robo_cli/app.py
+++ b/cli/src/robo_cli/app.py
@@ -1,23 +1,35 @@
-import json
+import logging
 import shutil
-import time
+import subprocess
 from pathlib import Path
-from typing import List
 
 import typer
 from rich.console import Console, Group
+from rich.logging import RichHandler
 from rich.panel import Panel
 from rich.prompt import IntPrompt, Prompt
-from rich.spinner import Spinner
 from rich.table import Table
 
-from robo_cli import environment, rcc, templates
+from robo_cli import core, environment, rcc, templates
 from robo_cli.config import pyproject
-from robo_cli.output import KIND_TO_EVENT, EndKeyword, StartKeyword
-from robo_cli.process import Process, ProcessError
+from robo_cli.output import EndKeyword, StartKeyword
+from robo_cli.process import ProcessError
 
 app = typer.Typer(no_args_is_help=True)
 console = Console(highlight=False)
+
+
+def ensure_environment() -> dict[str, str]:
+    try:
+        with console.status("Building environment"):
+            env = environment.ensure()
+    except ProcessError as err:
+        console.print(err.stderr)
+        raise typer.Exit(code=1)
+
+    env["RC_LOG_OUTPUT_STDOUT"] = "1"
+    env["PYTHONUNBUFFERED"] = "1"
+    return env
 
 
 @app.command()
@@ -44,8 +56,7 @@ def new():
     console.print("Initializing project")
     path = templates.copy_template(Path(project_name), template=template)
 
-    with console.status("Building environment"):
-        environment.ensure()
+    ensure_environment()
 
     console.print()
     console.print("✨ Project created ✨")
@@ -59,29 +70,11 @@ def new():
 @app.command()
 def list():
     """List available tasks"""
-    try:
-        with console.status("Building environment"):
-            env = environment.ensure()
-            env["RC_LOG_OUTPUT_STDOUT"] = "1"
-    except ProcessError as err:
-        console.print(err.stderr)
-        raise typer.Exit(code=1)
+    env = ensure_environment()
 
     with console.status("Parsing tasks"):
-        proc = Process(
-            [
-                "python",
-                "-m",
-                "robo",
-                "list",
-                "tasks.py",
-            ],
-            env=env,
-        )
-
         try:
-            stdout, _ = proc.run()
-            tasks = json.loads(stdout)
+            tasks = core.list_tasks(env)
         except ProcessError as err:
             console.print(err.stderr)
             raise typer.Exit(code=1)
@@ -102,40 +95,6 @@ def list():
     console.print()
 
 
-def robot_run():
-    spinner = Spinner("dots", "Running [bold]check-website[/bold]...")
-    yield spinner
-
-    time.sleep(2)
-
-    steps = [
-        "browser.open()",
-        'browser.goto("http://robocorp.com")',
-        "browser.take_screenshot()",
-    ]
-
-    status_spinner = Spinner("dots")
-
-    for prog in range(len(steps)):
-        table = Table()
-        table.add_column("Status")
-        table.add_column("Keyword")
-        for idx in range(prog + 1):
-            step = steps[idx]
-            table.add_row("🟢" if idx < prog else status_spinner, step)
-
-        yield Group(table, spinner)
-        time.sleep(2)
-
-    table = Table()
-    table.add_column("Status")
-    table.add_column("Keyword")
-    for step in steps:
-        table.add_row("🟢", step)
-
-    yield table
-
-
 @app.command()
 def run():
     """Runs the robot from current directory"""
@@ -146,78 +105,38 @@ def run():
     output_dir = Path(config.get("output", "output"))
     if output_dir.exists():
         shutil.rmtree(output_dir)
-    output_dir.mkdir()
+    output_dir.mkdir(parents=True)
 
     try:
-        with console.status("Building environment"):
-            env = environment.ensure()
-            env["RC_LOG_OUTPUT_STDOUT"] = "1"
+        env = ensure_environment()
 
         with console.status("Parsing tasks"):
-            proc = Process(
-                [
-                    "python",
-                    "-m",
-                    "robo",
-                    "list",
-                    "tasks.py",
-                ],
-                env=env,
-            )
-
             try:
-                stdout, _ = proc.run()
-                tasks = json.loads(stdout)
+                tasks = core.list_tasks(env)
             except ProcessError as err:
                 console.print(err.stderr)
                 raise typer.Exit(code=1)
 
         taskname = tasks[0]["name"]
+        stack = []
+
+        def on_event(event):
+            if isinstance(event, StartKeyword):
+                console.print(f"{(len(stack) + 1) * '  '}{event.name}")
+                stack.append(event)
+            if isinstance(event, EndKeyword):
+                stack.pop()
 
         with console.status(f"Running [bold]{taskname}[/bold]"):
-            env["RC_LOG_OUTPUT_STDOUT"] = "1"
-            env["PYTHONUNBUFFERED"] = "1"
-
-            # TODO: Figure out what to call from inner framework
-            proc = Process(
-                [
-                    "python",
-                    "-m",
-                    "robo",
-                    "run",
-                    "tasks.py",
-                    "-t",
-                    taskname,
-                ],
-                env=env,
-            )
-
-            stack = []
-
-            def handle_line(line: str):
-                try:
-                    payload = json.loads(line)
-                    klass = KIND_TO_EVENT[payload["message_type"]]
-                    event = klass.parse_obj(payload)
-                    # console.print(event)
-                    if isinstance(event, StartKeyword):
-                        console.print(f"{(len(stack) + 1) * '  '}{event.name}")
-                        stack.append(event)
-                    if isinstance(event, EndKeyword):
-                        stack.pop()
-                except ValueError:
-                    pass
-
-            proc.on_stdout(handle_line)
             console.print()
             console.print("[bold]Start execution[/bold]")
-            proc.run()
+            core.run_task(env, taskname, on_event)
             console.print()
 
     except ProcessError as exc:
-        print(exc.stderr)
-        console.print("---")
-        console.print("Run failed due to unexpected error")
+        # TODO: Handle this through events instead of printing stderr
+        console.print(exc.stderr)
+        console.print("[bold red]Run failed due to unexpected error[/bold red]")
         raise typer.Exit(code=1)
 
     artifacts = [str(name) for name in output_dir.glob("*")]
@@ -233,10 +152,28 @@ def run():
     console.print()
 
 
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+def exec(ctx: typer.Context):
+    """Run a command in the appropriate environment"""
+    if not ctx.args:
+        console.print("[bold red]No arguments given![/bold red]")
+        raise typer.Exit(code=1)
+
+    env = ensure_environment()
+
+    try:
+        console.print(f"[bold]{' '.join(ctx.args)}[/bold]")
+        subprocess.run(ctx.args, env=env, check=True)
+    except subprocess.CalledProcessError as err:
+        raise typer.Exit(code=err.returncode)
+
+
 @app.command()
 def export():
     """Exports the robot from current directory to a zip file"""
-    console.print()
+    # TODO: Fix this
     with console.status("Exporting robot"):
         path = rcc.robot_wrap()
 
@@ -247,9 +184,7 @@ def export():
 @app.command()
 def deploy():
     """Deploys the robot from current directory to Control Room"""
-    console.print()
-    console.print()
-
+    # TODO: Fix this
     with console.status("Fetching workspace list"):
         workspaces = rcc.cloud_workspace()
 
@@ -269,10 +204,8 @@ def deploy():
     robot_id = Prompt.ask("Robot id to deploy with?", default="example")
 
     console.print(
-        "Deploying [bold]example[/bold] to "
-        + f"[underline]{workspace_url}/robots/{robot_id}/[/underline]"
+        f"Deploying to [underline]{workspace_url}/robots/{robot_id}/[/underline]"
     )
-    console.print()
 
     # TODO: add an if to check for this. Currently this _only_ works for replacing
     # Confirm.ask("Project already exists, replace?")
@@ -286,61 +219,15 @@ def deploy():
     console.print()
 
 
-def _run(env, args: List[str]):
-    assert len(args) > 0, "Must provide at least one argument"
-    try:
-        proc = Process(args=args, env=env)
-
-        try:
-            stdout, stderr = proc.run()
-            # TODO: do we want to let black / ruff stdouts through?
-            # if stdout:
-            #     console.print(stdout)
-            # if stderr:
-            #     console.print(stderr)
-        except ProcessError as err:
-            console.print(f"Fail during {args[0]}")
-            console.print(err.stdout)
-            console.print(err.stderr)
-            raise typer.Exit(code=1)
-    except ProcessError as exc:
-        print(exc.stderr)
-        console.print("---")
-        console.print("Linting failed due to unexpected error")
-        raise typer.Exit(code=1)
-
-
-@app.command()
-def lint(fix: bool = typer.Option(False, "--fix", "-f")):
-    """Runs linting and formatting on the project"""
-
-    # TODO: generate ruff settings into the pyproject.toml
-    #
-    #    [tool.ruff]
-    #    # TODO: We should generate this inside the hood
-    #    target-version = "py39"
-
-    try:
-        with console.status("Building environment"):
-            env = environment.ensure_devdeps()
-    except ProcessError as err:
-        console.print("Error building linting environment")
-        console.print(err.stderr)
-        raise typer.Exit(code=1)
-
-    ruff_command = ["ruff", "check", "tasks.py"]
-    black_command = ["python", "-m", "black", "tasks.py"]
-
-    if fix:
-        ruff_command.insert(2, "--fix")
-        black_command.insert(3, "--check")
-
-    console.print()
-    with console.status("Linting and formatting"):
-        _run(env, ruff_command)
-        _run(env, black_command)
-    console.print("Linting and formatting succesful!")
-    console.print()
+@app.callback()
+def main(verbose: bool = False):
+    level = "NOTSET" if verbose else "ERROR"
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler()],
+    )
 
 
 if __name__ == "__main__":

--- a/cli/src/robo_cli/config/conda.py
+++ b/cli/src/robo_cli/config/conda.py
@@ -1,6 +1,6 @@
+import logging
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing_extensions import Literal
 
 import yaml
 
@@ -8,8 +8,10 @@ from robo_cli import paths
 
 from . import pyproject
 
+LOGGER = logging.getLogger(__name__)
 
-def generate(env: Literal["dependencies", "dev-dependencies"]) -> Path:
+
+def generate(develop=True) -> Path:
     config = pyproject.load()
 
     # TODO: Create some global place where we define this,
@@ -17,8 +19,7 @@ def generate(env: Literal["dependencies", "dev-dependencies"]) -> Path:
     python_version = config.get("python", "3.9.13")
     pip_version = "22.1.2"
 
-    dependencies = config.get(env, {})
-    pip_deps = _to_pip_deps(dependencies)
+    pip_deps = _generate_pip_deps(develop)
 
     content = {
         "channels": ["conda-forge"],
@@ -44,19 +45,36 @@ def generate(env: Literal["dependencies", "dev-dependencies"]) -> Path:
     return Path(tempfile.name)
 
 
-def _to_pip_deps(robo_deps):
-    pip_deps = []
-    for key, value in robo_deps.items():
+def _generate_pip_deps(develop: bool) -> list[str]:
+    config = pyproject.load()
+
+    dependencies = config.get("dependencies", {})
+    if develop:
+        dev_dependencies = config.get("dev-dependencies", {})
+        if duplicates := (dependencies.keys() & dev_dependencies.keys()):
+            names = ", ".join(duplicates)
+            raise ValueError(
+                f"Duplicate entries 'dependencies' and 'dev-dependencies': {names}"
+            )
+        dependencies.update(dev_dependencies)
+
+    LOGGER.debug(dependencies)
+    return _to_pip_deps(dependencies)
+
+
+def _to_pip_deps(dependencies: dict[str, str]) -> list[str]:
+    rows = []
+    for key, value in dependencies.items():
         key = str(key)
         value = str(value)
         if _is_file_path(value):
-            pip_deps.append(value)
+            rows.append(value)
         else:
-            pip_deps.append(f"{key}=={value}")
-    return pip_deps
+            rows.append(f"{key}=={value}")
+    return rows
 
 
-def _is_file_path(name: str):
+def _is_file_path(name: str) -> bool:
     try:
         return (paths.ROOT / name).is_file() or Path(name).absolute().is_file()
     except OSError:

--- a/cli/src/robo_cli/config/context.py
+++ b/cli/src/robo_cli/config/context.py
@@ -3,20 +3,17 @@ import shutil
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Literal
 
 from . import conda, robot
 
 
 @contextmanager
-def generate_configs(
-    deps_type: Literal["dependencies", "dev-dependencies"] = "dependencies"
-):
+def generate_configs(develop=True):
     conda_config = None
     robot_config = None
 
     try:
-        conda_config = conda.generate(deps_type)
+        conda_config = conda.generate(develop)
         robot_config = robot.generate(conda_config)
         yield conda_config, robot_config
     finally:

--- a/cli/src/robo_cli/core.py
+++ b/cli/src/robo_cli/core.py
@@ -1,0 +1,44 @@
+import json
+import logging
+from typing import Callable, TypedDict
+
+from .output import KIND_TO_EVENT, Event
+from .process import Process
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Task(TypedDict):
+    name: str
+    line: int
+    file: str
+    docs: str
+
+
+def list_tasks(env: dict[str, str]) -> list[Task]:
+    proc = Process(
+        ["python", "-m", "robo", "list", "tasks.py"],
+        env=env,
+    )
+    stdout, _ = proc.run()
+    tasks = json.loads(stdout)
+    return tasks
+
+
+def run_task(env: dict[str, str], taskname: str, on_event: Callable[[Event], None]):
+    proc = Process(
+        ["python", "-m", "robo", "run", "tasks.py", "-t", taskname],
+        env=env,
+    )
+
+    def handle_line(line: str):
+        try:
+            payload = json.loads(line)
+            klass = KIND_TO_EVENT[payload["message_type"]]
+            event = klass.parse_obj(payload)
+            on_event(event)
+        except Exception as exc:
+            LOGGER.debug(f"Unhandled exception in listener: {exc}")
+
+    proc.on_stdout(handle_line)
+    proc.run()

--- a/cli/src/robo_cli/output.py
+++ b/cli/src/robo_cli/output.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Type
+from typing import Type, Union
 
 from pydantic import BaseModel
 
@@ -108,7 +108,26 @@ class StartTime(BaseModel):
     start_time_delta: float
 
 
-KIND_TO_EVENT: dict[MessageType, Type[BaseModel]] = {
+Event = Union[
+    Version,
+    Info,
+    Id,
+    InitialTime,
+    Log,
+    LogHtml,
+    StartSuite,
+    EndSuite,
+    StartTask,
+    EndTask,
+    StartKeyword,
+    EndKeyword,
+    KeywordArgument,
+    AssignKeyword,
+    Tag,
+    StartTime,
+]
+
+KIND_TO_EVENT: dict[MessageType, Type[Event]] = {
     MessageType.VERSION: Version,
     MessageType.INFO: Info,
     MessageType.ID: Id,

--- a/cli/src/robo_cli/process.py
+++ b/cli/src/robo_cli/process.py
@@ -75,7 +75,7 @@ class Process:
         args: List[str],
         cwd: Optional[PathLike] = None,
         env: Optional[Dict[str, str]] = None,
-        shell=IS_WINDOWS,  # TODO: Remove later
+        shell=False,
     ):
         self._args = args
         self._cwd = cwd or Path.cwd()
@@ -115,11 +115,12 @@ class Process:
             stdout_reader.start()
             stderr_reader.start()
 
-            self._proc = proc
-            self._proc.wait()
-
-            stdout_reader.close()
-            stderr_reader.close()
+            try:
+                self._proc = proc
+                self._proc.wait()
+            finally:
+                stdout_reader.close()
+                stderr_reader.close()
 
             stdout_reader.join(timeout=5)
             stderr_reader.join(timeout=5)

--- a/cli/tasks.py
+++ b/cli/tasks.py
@@ -23,7 +23,7 @@ def poetry(ctx, *parts):
 
 @task
 def install(ctx):
-    poetry("install")
+    poetry(ctx, "install")
 
     # Download RCC
     filename = "rcc.exe" if platform.system() == "Windows" else "rcc"
@@ -54,6 +54,12 @@ def typecheck(ctx):
 def test(ctx):
     """Run unittests"""
     poetry(ctx, "run pytest")
+
+
+@task(lint, typecheck, test)
+def check_all(ctx):
+    """Run all checks"""
+    pass
 
 
 @task

--- a/examples/rpa-challenge/pyproject.toml
+++ b/examples/rpa-challenge/pyproject.toml
@@ -10,7 +10,3 @@ robo-libs="robo_libs-0.1.0-py3-none-any.whl"
 [tool.robo.dev-dependencies]
 ruff="0.0.260"
 black="23.3.0"
-
-[tool.ruff]
-# TODO: We should generate this inside the hood
-target-version = "py39"


### PR DESCRIPTION
Hijacked the `robo lint` PR and re-scoped to be a more generic solution (for now).

- Adds support for the `dev-dependencies` section in `pyproject.toml`
- Adds support for `robo exec` which runs any arbitrary command in the rcc environment

Usage of a linter would mean:
1. Adding the tool (such as ruff or black) to `tool.robo.dev-dependencies`
2. Running it through robo, e.g. `robo exec ruff .`