### PR TITLE
vault: allow creating and updating vault secrets directly

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -1,34 +1,143 @@
 # Robocorp Control Room Vault API library
 
-`robocorp-vault` is a library which provides read and write access to the
-`Vault` at `Robocorp Control Room`.
+`robocorp-vault` is a library that provides read and write access to the [Vault](https://robocorp.com/docs/development-guide/variables-and-secrets/vault)
+in Robocorp Control Room, which can be used to store and retrieve secret values such as passwords.
 
 ## Usage
 
-```python    
+### Reading secrets
+
+A secret consists of a name, an optional description, and a map of
+keys and values. For instance, one secret can be login credentials for a website,
+which includes both a username and a password:
+
+```python
+from robocorp.tasks import task
 from robocorp import vault
-from robocorp import log 
 
-def reading_secrets():
-    secrets_container = vault.get_secret('secret_name')
-    # Shows secret keys available:
-    print(f"My secrets: {secrets_container}")
-    # Note: actually prints the secret value below.
-    print(f"Username: {secrets_container['username']}")
-
-def modifying_secrets():
-    secret = vault.get_secret("swaglabs")
-    with log.suppress_variables():
-        secret_value = collect_new_secret_value()
-        secret["username"] = secret_value
-        vault.set_secret(secret)
+@task
+def inspect_secret():
+    secret = vault.get_secret("login_credentials")
+    print("Secret name:", secret.name)
+    print("Secret description:", secret.description)
+    print("Secret keys:", secret.keys())
+    print("Secret value:", secret["username"])
 ```
 
-Note that values set or gotten from the vault will be automatically
-hidden from `robocorp.log` logs (if `robocorp.log` is available
-in the environment), but care needs to be taken when setting it
-so that secrets don't become exposed before being set into the vault.
+### Creating secrets
 
-i.e.: When setting values into the vault, if such values are sensitive,
-use `with robocorp.log.suppress_variables()` so that such value doesn't
-become logged before it's received by the vault.
+Secrets can be also created and updated from within the execution:
+
+```python
+import secrets
+
+from robocorp.tasks import task
+from robocorp import vault
+
+@task
+def create_secret():
+    vault.create_secret(
+        name="generated_token",
+        description="This secret was created by an automation",
+        values={
+            "username": "bot@example.com",
+            "token": secrets.token_urlsafe(16),
+        }
+    )
+```
+
+### Updating secrets
+
+Sometimes it's necessary to update parts of an existing secret:
+
+```python
+import secrets
+
+from robocorp.tasks import task
+from robocorp import vault
+
+@task
+def update_secret():
+    secret = vault.get_secret("generated_token")
+    secret["token"] = secrets.token_urlsafe(16)
+    vault.set_secret(secret)
+```
+
+## Hiding values
+
+Secret values (either received or sent) will be automatically hidden by the
+library, if the library `robocorp.log` is available in the environment. It is
+still imperative that any code that handles secret values does not expose
+them by accident before interacting with Vault.
+
+For example, when setting new values hide all variables already in the
+enclosing scope:
+
+```python
+from robocorp.tasks import task
+from robocorp import vault, log
+
+
+@task
+def sensitive_data():
+    with log.suppress_variables():
+        username, password = generate_credentials()
+        vault.set_secret("credentials", {
+            "username": username,
+            "password": password,
+        })
+```
+
+## Local development
+
+### Connecting to Control Room
+
+The usage of Vault relies on environment variables, which are normally set
+automatically by the Robocorp Agent or Assistant when a run is executed via
+Control Room.
+
+When developing robots locally in VSCode, you can use the
+[Robocorp Code Extension](https://robocorp.com/docs/developer-tools/visual-studio-code/extension-features#connecting-to-control-room-vault)
+to set these variables automatically as well.
+
+Alternatively, you may set these environment variables manually using
+[rcc](https://robocorp.com/docs/rcc/workflow) or directly in some other fashion.
+The specific variables which must exist are:
+
+- ``RC_API_SECRET_HOST``: URL to Robocorp Vault API
+- ``RC_API_SECRET_TOKEN``: API Token for Robocorp Vault API
+- ``RC_WORKSPACE_ID``: Control Room Workspace ID
+
+### Using mock Vault
+
+An alternative to using Vault from Control Room is to use a local file
+with mock secrets. This enables development of a Robot without any existing
+Control Room workspace.
+
+**Note:** Secrets stored in a file are not safe to use with sensitive values,
+and should only be used during development-time
+
+File-based secrets can be set by defining two environment variables.
+
+- ``RC_VAULT_SECRET_MANAGER``: ``FileSecrets`
+- ``RC_VAULT_SECRET_FILE``: Absolute path to the secrets database file
+
+Example content of local secrets file:
+
+```json
+{
+    "swaglabs": {
+        "username": "standard_user",
+        "password": "secret_sauce"
+    }
+}
+```
+
+OR
+
+```yaml
+
+swaglabs:
+    username: standard_user
+    password: secret_sauce
+```

--- a/vault/docs/README.md
+++ b/vault/docs/README.md
@@ -4,7 +4,7 @@
 
 ## Modules
 
-- [`robocorp.vault`](./robocorp.vault.md#module-robocorpvault): `robocorp.vault` is a library for interacting with secrets stored in the ``Robocorp Control Room Vault``.
+- [`robocorp.vault`](./robocorp.vault.md#module-robocorpvault)
 
 ## Classes
 
@@ -12,8 +12,9 @@
 
 ## Functions
 
-- [`vault.get_secret`](./robocorp.vault.md#function-get_secret): Get secret defined with given name.
-- [`vault.set_secret`](./robocorp.vault.md#function-set_secret): Overwrite an existing secret with new values.
+- [`vault.create_secret`](./robocorp.vault.md#function-create_secret): Create a new secret, or overwrite an existing one.
+- [`vault.get_secret`](./robocorp.vault.md#function-get_secret): Get a secret with the given name.
+- [`vault.set_secret`](./robocorp.vault.md#function-set_secret): Set a secret value using an existing container.
 
 
 ---

--- a/vault/docs/changelog.md
+++ b/vault/docs/changelog.md
@@ -1,3 +1,8 @@
+1.2.0 (unreleased)
+-----------------------------
+
+- Add method `create_secret` for creating new secrets in Vault
+
 1.1.0 (2023-07-12)
 -----------------------------
 
@@ -7,9 +12,9 @@
 1.0.0
 -----------------------------
 
-- In the file backend if an error happens such error is thrown.
+- In the file backend if an error happens such error is thrown
 - Besides automatically hiding secret values from the log as `str(value)`, values
-  are also hidden as `repr(value)`.
+  are also hidden as `repr(value)`
 
 
 0.4.0
@@ -20,4 +25,4 @@
 0.3.0
 -----------------------------
 
-- Updated APIs. Public APIs are now: `robocorp.vault.get_secret` and `robocorp.vault.set_secret`.
+- Updated APIs. Public APIs are now: `robocorp.vault.get_secret` and `robocorp.vault.set_secret`

--- a/vault/docs/robocorp.vault.md
+++ b/vault/docs/robocorp.vault.md
@@ -3,64 +3,9 @@
 <a href="../../vault/src/robocorp/vault/__init__.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 # <kbd>module</kbd> `robocorp.vault`
-`robocorp.vault` is a library for interacting with secrets stored in the ``Robocorp Control Room Vault``. 
-
-Uses ``Robocorp Control Room Vault`` (by default) or file-based secrets, which can be taken into use by setting some environment variables. 
-
-Robocorp Vault relies on environment variables, which are normally set automatically by the Robocorp Work Agent or Assistant when a run is initialized by the Robocorp Control Room. When developing robots locally in VSCode, you can use the `Robocorp Code Extension`_ to set these variables automatically as well. 
-
-Alternatively, you may set these environment variable manually using `rcc`_ or directly in some other fashion. The specific variables which must exist are: 
-
-
-- ``RC_API_SECRET_HOST``: URL to Robocorp Vault API 
-- ``RC_API_SECRET_TOKEN``: API Token for Robocorp Vault API 
-- ``RC_WORKSPACE_ID``: Control Room Workspace ID 
-
-.. _Robocorp Control Room Vault: https://robocorp.com/docs/development-guide/variables-and-secrets/vault .. _Robocorp Code Extension: https://robocorp.com/docs/developer-tools/visual-studio-code/extension-features#connecting-to-control-room-vault .. _rcc: https://robocorp.com/docs/rcc/workflow 
-
-File-based secrets can be set by defining two environment variables. 
-
-
-- ``RC_VAULT_SECRET_MANAGER``: FileSecrets 
-- ``RC_VAULT_SECRET_FILE``: Absolute path to the secrets database file 
-
-Example content of local secrets file: 
-
-```json
-{
-     "swaglabs": {
-         "username": "standard_user",
-         "password": "secret_sauce"
-     }
-}
-``` 
-
-OR 
-
-```yaml
-
-swaglabs:
-     username: standard_user
-     password: secret_sauce
-``` 
 
 
 
-**Example:**
- 
-
-```python    
-from robocorp import vault
-
-def reading_secrets():
-     secrets_container = vault.get_secret('swaglabs')
-     print(f"My secrets: {secrets_container}")
-     
-def modifying_secrets():
-     secret = vault.get_secret("swaglabs")
-     secret["username"] = "nobody"
-     vault.set_secret(secret)
-``` 
 
 **Global Variables**
 ---------------
@@ -68,36 +13,32 @@ def modifying_secrets():
 
 ---
 
-<a href="../../vault/src/robocorp/vault/__init__.py#L82"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../../vault/src/robocorp/vault/__init__.py#L19"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ## <kbd>function</kbd> `get_secret`
 
 ```python
-get_secret(secret_name: str) → SecretContainer
+get_secret(name: str, hide: bool = True) → SecretContainer
 ```
 
-Get secret defined with given name. 
+Get a secret with the given name. 
 
 
 
 **Args:**
  
- - <b>`secret_name`</b>:  Name of secret to fetch. 
+ - <b>`name`</b>:  Name of secret to fetch 
+ - <b>`hide`</b>:  Hide secret values from log output 
 
 
 
 **Note:**
 
-> The returned secret is not cached, so, calling this function again may do a new network roundtrip. 
->
-
-**Note:**
-
-> When used, if `robocorp.log` is in the environment, all the values gotten will be automatically hidden from the logs. i.e.: For each value, `log.hide_from_output(value)` will be called. 
+> If `robocorp.log` is available in the environment, the `hide` argument controls if the given values are automatically hidden in the log output. 
 >
 
 **Returns:**
- The container for the secret (which has key-value pairs). 
+ Secret container of name, description, and key-value pairs 
 
 
 
@@ -108,31 +49,80 @@ Get secret defined with given name.
 
 ---
 
-<a href="../../vault/src/robocorp/vault/__init__.py#L128"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+<a href="../../vault/src/robocorp/vault/__init__.py#L47"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
 
 ## <kbd>function</kbd> `set_secret`
 
 ```python
-set_secret(secret: SecretContainer) → None
+set_secret(secret: SecretContainer, hide: bool = True) → None
 ```
 
-Overwrite an existing secret with new values. 
+Set a secret value using an existing container. 
+
+**Note:** If the secret already exists, all contents are replaced. 
 
 
-
-**Note:**
-
-> Only allows modifying existing secrets, and replaces all values contained within it. 
->
-
-**Note:**
-
-> When used, if `robocorp.log` is in the environment, all the values set will be automatically hidden from the logs. i.e.: For each value, `log.hide_from_output(value)` will be called. 
->
 
 **Args:**
  
- - <b>`secret`</b>:  the secret object which was mutated. 
+ - <b>`secret`</b>:  Secret container, created manually or returned by `get_secret` 
+ - <b>`hide`</b>:  Hide secret values from log output 
+
+
+
+**Note:**
+
+> If `robocorp.log` is available in the environment, the `hide` argument controls if the given values are automatically hidden in the log output. 
+>
+
+**Raises:**
+ 
+ - <b>`RobocorpVaultError`</b>:  Error with API request or response payload 
+
+
+---
+
+<a href="../../vault/src/robocorp/vault/__init__.py#L72"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>function</kbd> `create_secret`
+
+```python
+create_secret(
+    name: str,
+    values: dict[str, Any],
+    description: str = '',
+    exist_ok: bool = False,
+    hide: bool = True
+) → SecretContainer
+```
+
+Create a new secret, or overwrite an existing one. 
+
+
+
+**Args:**
+ 
+ - <b>`name`</b>:  Name of secret 
+ - <b>`values`</b>:  Mapping of secret keys and values 
+ - <b>`description`</b>:  Optional description for secret 
+ - <b>`exist_ok`</b>:  Overwrite existing secret 
+ - <b>`hide`</b>:  Hide secret values from log output 
+
+
+
+**Note:**
+
+> If `robocorp.log` is available in the environment, the `hide` argument controls if the given values are automatically hidden in the log output. 
+>
+
+**Returns:**
+ Secret container of name, description, and key-value pairs 
+
+
+
+**Raises:**
+ 
+ - <b>`RobocorpVaultError`</b>:  Error with API request or response payload 
 
 
 

--- a/vault/poetry.lock
+++ b/vault/poetry.lock
@@ -350,14 +350,14 @@ files = [
 
 [[package]]
 name = "invoke"
-version = "2.1.3"
+version = "2.2.0"
 description = "Pythonic task execution"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "invoke-2.1.3-py3-none-any.whl", hash = "sha256:51e86a08d964160e01c44eccd22f50b25842bd96a9c63c11177032594cb86740"},
-    {file = "invoke-2.1.3.tar.gz", hash = "sha256:a3b15d52d50bbabd851b8a39582c772180b614000fa1612b4d92484d54d38c6b"},
+    {file = "invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820"},
+    {file = "invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5"},
 ]
 
 [[package]]

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "robocorp-vault"
-version = "1.1.0"
+version = "1.2.0"
 description = "Robocorp Control Room Vault API integration library"
 authors = [
 	"Fabio Z. <fabio@robocorp.com>",

--- a/vault/src/robocorp/vault/__init__.py
+++ b/vault/src/robocorp/vault/__init__.py
@@ -1,74 +1,11 @@
-"""`robocorp.vault` is a library for interacting with secrets stored in the ``Robocorp Control Room Vault``.
-
-Uses ``Robocorp Control Room Vault`` (by default) or file-based secrets, which can be taken
-into use by setting some environment variables.
-
-Robocorp Vault relies on environment variables, which are normally set
-automatically by the Robocorp Work Agent or Assistant when a run is
-initialized by the Robocorp Control Room. When developing robots locally
-in VSCode, you can use the `Robocorp Code Extension`_ to set these
-variables automatically as well.
-
-Alternatively, you may set these environment variable manually using
-`rcc`_ or directly in some other fashion. The specific variables which
-must exist are:
-
-- ``RC_API_SECRET_HOST``: URL to Robocorp Vault API
-- ``RC_API_SECRET_TOKEN``: API Token for Robocorp Vault API
-- ``RC_WORKSPACE_ID``: Control Room Workspace ID
-
-.. _Robocorp Control Room Vault: https://robocorp.com/docs/development-guide/variables-and-secrets/vault
-.. _Robocorp Code Extension: https://robocorp.com/docs/developer-tools/visual-studio-code/extension-features#connecting-to-control-room-vault
-.. _rcc: https://robocorp.com/docs/rcc/workflow
-
-File-based secrets can be set by defining two environment variables.
-
-- ``RC_VAULT_SECRET_MANAGER``: FileSecrets
-- ``RC_VAULT_SECRET_FILE``: Absolute path to the secrets database file
-
-Example content of local secrets file:
-
-```json
-{
-    "swaglabs": {
-        "username": "standard_user",
-        "password": "secret_sauce"
-    }
-}
-```
-
-OR
-
-```yaml
-
-swaglabs:
-    username: standard_user
-    password: secret_sauce
-```
-
-Example:
-
-```python    
-from robocorp import vault
-
-def reading_secrets():
-    secrets_container = vault.get_secret('swaglabs')
-    print(f"My secrets: {secrets_container}")
-    
-def modifying_secrets():
-    secret = vault.get_secret("swaglabs")
-    secret["username"] = "nobody"
-    vault.set_secret(secret)
-```
-"""  # noqa: E501
-
-
 from contextlib import nullcontext
 from functools import lru_cache
+from typing import Any
 
+from ._errors import RobocorpVaultError
 from ._secrets import SecretContainer
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 version_info = [int(x) for x in __version__.split(".")]
 
 
@@ -79,91 +16,119 @@ def _get_vault():
     return Vault()
 
 
-def get_secret(secret_name: str) -> SecretContainer:
-    """Get secret defined with given name.
+def get_secret(name: str, hide: bool = True) -> SecretContainer:
+    """Get a secret with the given name.
 
     Args:
-        secret_name: Name of secret to fetch.
+        name: Name of secret to fetch
+        hide: Hide secret values from log output
 
     Note:
-        The returned secret is not cached, so, calling this function again
-        may do a new network roundtrip.
-
-    Note:
-        When used, if `robocorp.log` is in the environment, all the values
-        gotten will be automatically hidden from the logs.
-        i.e.: For each value, `log.hide_from_output(value)` will be called.
+        If `robocorp.log` is available in the environment, the `hide` argument
+        controls if the given values are automatically hidden in the log
+        output.
 
     Returns:
-        The container for the secret (which has key-value pairs).
+        Secret container of name, description, and key-value pairs
 
     Raises:
         RobocorpVaultError: Error with API request or response payload.
     """
-    try:
-        from robocorp import log  # type: ignore [attr-defined]
-
-        ctx = log.suppress_variables()
-        has_log = True
-    except ImportError:
-        pass  # If robocorp.log is not being used that's OK.
-        ctx = nullcontext()
-        has_log = False
-
-    with ctx:
+    with _suppress_variables():
         vault = _get_vault()
+        secret = vault.get_secret(name)
 
-        # Note: secrets are always gotten from the backend when requested
-        # (so any updates will be gotten in a new `get_secret` call).
-        secret = vault.get_secret(secret_name)
+        if hide:
+            _hide_secret_values(secret)
 
-        if has_log:
-            # There's no caching in place, so, on any new call it's possible
-            # that values changed, so, call this every time.
-            _ignore_secret_values(secret)
-
-    return secret
+        return secret
 
 
-def set_secret(secret: SecretContainer) -> None:
-    """Overwrite an existing secret with new values.
+def set_secret(secret: SecretContainer, hide: bool = True) -> None:
+    """Set a secret value using an existing container.
 
-    Note:
-        Only allows modifying existing secrets, and replaces
-          all values contained within it.
-
-    Note:
-        When used, if `robocorp.log` is in the environment, all the values
-        set will be automatically hidden from the logs.
-        i.e.: For each value, `log.hide_from_output(value)` will be called.
+    **Note:** If the secret already exists, all contents are replaced.
 
     Args:
-        secret: the secret object which was mutated.
+        secret: Secret container, created manually or returned by `get_secret`
+        hide: Hide secret values from log output
+
+    Note:
+        If `robocorp.log` is available in the environment, the `hide` argument
+        controls if the given values are automatically hidden in the log
+        output.
+
+    Raises:
+        RobocorpVaultError: Error with API request or response payload
     """
-    try:
-        from robocorp import log  # type: ignore [attr-defined]
-
-        ctx = log.suppress_variables()
-        has_log = True
-    except ImportError:
-        pass  # If robocorp.log is not being used that's OK.
-        ctx = nullcontext()
-        has_log = False
-
-    with ctx:
+    with _suppress_variables():
         vault = _get_vault()
         vault.set_secret(secret)
 
-        if has_log:
-            # When it's set it's expected that some value was changed, so,
-            # start hiding it from the logs.
-            # Note: users should've actually done that already, but doing
-            # it again is harmless.
-            _ignore_secret_values(secret)
+        if hide:
+            _hide_secret_values(secret)
 
 
-def _ignore_secret_values(secret):
-    from robocorp import log
+def create_secret(
+    name: str,
+    values: dict[str, Any],
+    description: str = "",
+    exist_ok: bool = False,
+    hide: bool = True,
+) -> SecretContainer:
+    """Create a new secret, or overwrite an existing one.
+
+    Args:
+        name: Name of secret
+        values: Mapping of secret keys and values
+        description: Optional description for secret
+        exist_ok: Overwrite existing secret
+        hide: Hide secret values from log output
+
+    Note:
+        If `robocorp.log` is available in the environment, the `hide` argument
+        controls if the given values are automatically hidden in the log
+        output.
+
+    Returns:
+        Secret container of name, description, and key-value pairs
+
+    Raises:
+        RobocorpVaultError: Error with API request or response payload
+    """
+    with _suppress_variables():
+        vault = _get_vault()
+        if not exist_ok:
+            try:
+                vault.get_secret(name)
+            except Exception:
+                pass
+            else:
+                raise RobocorpVaultError(f"Secret with name '{name}' already exists")
+
+        secret = SecretContainer(
+            name=name,
+            description=description,
+            values=values,
+        )
+        set_secret(secret, hide=hide)
+        return secret
+
+
+def _suppress_variables():
+    try:
+        from robocorp import log  # type: ignore [attr-defined]
+
+        return log.suppress_variables()
+    except ImportError:
+        return nullcontext()
+
+
+def _hide_secret_values(secret):
+    try:
+        from robocorp import log
+    except ImportError:
+        return
 
     for value in secret.values():
         s = str(value)
@@ -180,4 +145,10 @@ def _ignore_secret_values(secret):
             log.hide_from_output(r.replace("\\", "\\\\"))
 
 
-__all__ = ["get_secret", "set_secret"]
+__all__ = [
+    "get_secret",
+    "set_secret",
+    "create_secret",
+    "SecretContainer",
+    "RobocorpVaultError",
+]

--- a/vault/src/robocorp/vault/_vault.py
+++ b/vault/src/robocorp/vault/_vault.py
@@ -78,11 +78,7 @@ class Vault:
         return self.adapter.get_secret(secret_name)
 
     def set_secret(self, secret: SecretContainer) -> None:
-        """Overwrite an existing secret with new values.
-
-        Note:
-            Only allows modifying existing secrets, and replaces
-              all values contained within it.
+        """Create secret or overwrite existing.
 
         Args:
             secret: `SecretContainer` object, from e.g. `get_secret`.

--- a/vault/tests/robocorp_vault_tests/test_vault_api.py
+++ b/vault/tests/robocorp_vault_tests/test_vault_api.py
@@ -37,6 +37,24 @@ def test_vault_api(monkeypatch, datadir, clear_cached_vault):
     assert "10" in secret_container
     assert secret_container[10] == 10
 
+    vault.create_secret(
+        "generated",
+        {"a-key": "a-value"},
+        description="Some sort of secret",
+    )
+
+    secret_container = vault.get_secret("generated")
+    assert secret_container.name == "generated"
+    assert len(secret_container) == 1
+    assert secret_container["a-key"] == "a-value"
+
+    with pytest.raises(vault.RobocorpVaultError):
+        vault.create_secret("generated", {})
+
+    vault.create_secret("generated", {"a-key": "another-value"}, exist_ok=True)
+    secret_container = vault.get_secret("generated")
+    assert secret_container["a-key"] == "another-value"
+
 
 @pytest.fixture
 def log_to_stderr():


### PR DESCRIPTION
Turns out that it's possible to both create and update Vault values, not just update existing ones. This was (for some reason) documented differently from the implementation.

Overall, the `set_secret` method was clunky to use since it expected an existing container instance. In this PR that is changed to accept new fields directly (name, description, key-values mapping). An argument `exist_ok` was added to allow overwriting existing values explicitly.