### PR TITLE
Always enable faulthandler when running tasks.

### DIFF
--- a/tasks/src/robocorp/tasks/_commands.py
+++ b/tasks/src/robocorp/tasks/_commands.py
@@ -130,6 +130,12 @@ def run(
         context.show_error(f"Path: {path} does not exist")
         return 1
 
+    # Enable faulthandler (writing to sys.stderr) early on in the
+    # task execution process.
+    import faulthandler
+
+    faulthandler.enable()
+
     from robocorp import log
 
     task_names: Sequence[str]


### PR DESCRIPTION
Note: we could also write to a file, but it's a bit annoying that we have to pre-create the file and then erase it `atexit` if it didn't crash otherwise the file would be leaked.