### PR TITLE
workitems: more strict behaviour in FileAdapter to match CR

### DIFF
--- a/workitems/docs/CHANGELOG.md
+++ b/workitems/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Prevent invalid operations on released work items with `FileAdapter`
+
 ## 1.4.0 - 2023-09-07
 
 - Add support for `RC_DISABLE_SSL`


### PR DESCRIPTION
Adding some extra validity checks in FileAdapter to make it match Control Room behaviour better