### PR TITLE
tasks: add setup/teardown fixtures

### DIFF
--- a/devutils/src/devutils/invoke_utils.py
+++ b/devutils/src/devutils/invoke_utils.py
@@ -163,9 +163,9 @@ def build_common_tasks(root: Path, package_name: str, tag_prefix: Optional[str] 
             poetry(ctx, f"run pylint --rcfile {ROOT / '.pylintrc'} src")
 
     @task
-    def typecheck(ctx):
+    def typecheck(ctx, strict: bool = False):
         """Type check code"""
-        poetry(
+        cmd = [
             ctx,
             "run mypy",
             "--follow-imports=silent",
@@ -173,7 +173,10 @@ def build_common_tasks(root: Path, package_name: str, tag_prefix: Optional[str] 
             "--namespace-packages",
             "--explicit-package-bases",
             f"-p {package_name}",
-        )
+        ]
+        if strict:
+            cmd.append("--strict")
+        poetry(*cmd)
 
     @task
     def pretty(ctx):

--- a/tasks/docs/api/README.md
+++ b/tasks/docs/api/README.md
@@ -9,13 +9,15 @@
 
 ## Classes
 
-- No classes
+- [`_protocols.ITask`](./robocorp.tasks._protocols.md#class-itask)
 
 ## Functions
 
 - [`tasks.get_current_task`](./robocorp.tasks.md#function-get_current_task): Provides the task which is being currently run or None if not currently
 - [`tasks.get_output_dir`](./robocorp.tasks.md#function-get_output_dir): Provide the output directory being used for the run or None if there's no
 - [`tasks.session_cache`](./robocorp.tasks.md#function-session_cache): Provides decorator which caches return and clears automatically when all
+- [`_fixtures.setup`](./robocorp.tasks._fixtures.md#function-setup): Run code before any tasks start, or before each separate task.
 - [`tasks.task`](./robocorp.tasks.md#function-task): Decorator for tasks (entry points) which can be executed by `robocorp.tasks`.
 - [`tasks.task_cache`](./robocorp.tasks.md#function-task_cache): Provides decorator which caches return and clears it automatically when the
+- [`_fixtures.teardown`](./robocorp.tasks._fixtures.md#function-teardown): Run code after tasks have been run, or after each separate task.
 - [`cli.main`](./robocorp.tasks.cli.md#function-main): Entry point for running tasks from robocorp-tasks.

--- a/tasks/docs/api/robocorp.tasks.cli.md
+++ b/tasks/docs/api/robocorp.tasks.cli.md
@@ -14,7 +14,7 @@ ______________________________________________________________________
 
 ## function `main`
 
-**Source:** [`cli.py:19`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/cli.py#L19)
+**Source:** [`cli.py:28`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/cli.py#L28)
 
 ```python
 main(args=None, exit: bool = True) → int

--- a/tasks/docs/api/robocorp.tasks.md
+++ b/tasks/docs/api/robocorp.tasks.md
@@ -38,7 +38,7 @@ ______________________________________________________________________
 
 ## function `task`
 
-**Source:** [`__init__.py:43`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L43)
+**Source:** [`__init__.py:44`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L44)
 
 ```python
 task(func)
@@ -64,9 +64,99 @@ python -m robocorp.tasks run tasks.py -t enter_user
 
 ______________________________________________________________________
 
+## function `setup`
+
+**Source:** [`_fixtures.py:24`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_fixtures.py#L24)
+
+```python
+setup(
+    *args,
+    **kwargs
+) → Union[Callable[[Sequence[ITask]], Any], Callable[[Callable[[Sequence[ITask]], Any]], Callable[[Sequence[ITask]], Any]], Callable[[Callable[[ITask], Any]], Callable[[ITask], Any]]]
+```
+
+Run code before any tasks start, or before each separate task.
+
+Receives as an argument the task or tasks that will be run.
+
+Can be used as a decorator without arguments:
+
+```python
+from robocorp.tasks import setup
+
+@setup
+def my_fixture(task):
+    print(f"Before task: {task.name}")
+```
+
+Alternatively, can be called with a `scope` argument to decide when the fixture is run:
+
+```python
+from robocorp.tasks import setup
+
+@setup(scope="task")
+def before_each(task):
+    print(f"Running task '{task.name}'")
+
+@setup(scope="session")
+def before_all(tasks):
+    print(f"Running {len(tasks)} task(s)")
+```
+
+By default, runs setups in `task` scope.
+
+**Note:** If fixtures are defined in another file, they need to be imported in the main tasks file to be taken into use
+
+______________________________________________________________________
+
+## function `teardown`
+
+**Source:** [`_fixtures.py:102`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_fixtures.py#L102)
+
+```python
+teardown(
+    *args,
+    **kwargs
+) → Union[Callable[[Sequence[ITask]], Any], Callable[[Callable[[Sequence[ITask]], Any]], Callable[[Sequence[ITask]], Any]], Callable[[Callable[[ITask], Any]], Callable[[ITask], Any]]]
+```
+
+Run code after tasks have been run, or after each separate task.
+
+Receives as an argument the task or tasks that were executed, which contain (among other things) the resulting status and possible error message.
+
+Can be used as a decorator without arguments:
+
+```python
+from robocorp.tasks import teardown
+
+@teardown
+def my_fixture(task):
+    print(f"After task: {task.name})
+```
+
+Alternatively, can be called with a `scope` argument to decide when the fixture is run:
+
+```python
+from robocorp.tasks import teardown
+
+@teardown(scope="task")
+def after_each(task):
+    print(f"Task '{task.name}' status is '{task.status}'")
+
+@teardown(scope="session")
+def after_all(tasks):
+    print(f"Executed {len(tasks)} task(s)")
+```
+
+By default, runs teardowns in `task` scope.
+
+**Note:** If fixtures are defined in another file, they need to be imported in the main tasks file to be taken into use
+
+______________________________________________________________________
+
 ## function `session_cache`
 
-**Source:** [`__init__.py:74`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L74)
+**Source:** [`__init__.py:75`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L75)
 
 ```python
 session_cache(func)
@@ -86,7 +176,7 @@ ______________________________________________________________________
 
 ## function `task_cache`
 
-**Source:** [`__init__.py:96`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L96)
+**Source:** [`__init__.py:97`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L97)
 
 ```python
 task_cache(func)
@@ -106,7 +196,7 @@ ______________________________________________________________________
 
 ## function `get_output_dir`
 
-**Source:** [`__init__.py:118`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L118)
+**Source:** [`__init__.py:119`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L119)
 
 ```python
 get_output_dir() → Optional[Path]
@@ -118,10 +208,34 @@ ______________________________________________________________________
 
 ## function `get_current_task`
 
-**Source:** [`__init__.py:131`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L131)
+**Source:** [`__init__.py:132`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/__init__.py#L132)
 
 ```python
 get_current_task() → Optional[ITask]
 ```
 
 Provides the task which is being currently run or None if not currently running a task.
+
+______________________________________________________________________
+
+## class `ITask`
+
+**Source:** [`_protocols.py:45`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_protocols.py#L45)
+
+#### property `failed`
+
+Returns true if the task failed. (in which case usually exc_info is not None).
+
+#### property `lineno`
+
+#### property `name`
+
+______________________________________________________________________
+
+### method `run`
+
+**Source:** [`_protocols.py:62`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_protocols.py#L62)
+
+```python
+run() → None
+```

--- a/tasks/docs/api/robocorp.tasks.md
+++ b/tasks/docs/api/robocorp.tasks.md
@@ -66,13 +66,13 @@ ______________________________________________________________________
 
 ## function `setup`
 
-**Source:** [`_fixtures.py:24`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_fixtures.py#L24)
+**Source:** [`_fixtures.py:26`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_fixtures.py#L26)
 
 ```python
 setup(
     *args,
     **kwargs
-) → Union[Callable[[Sequence[ITask]], Any], Callable[[Callable[[Sequence[ITask]], Any]], Callable[[Sequence[ITask]], Any]], Callable[[Callable[[ITask], Any]], Callable[[ITask], Any]]]
+) → Union[Callable[[ITask], Any], Callable[[Callable[[ITask], Any]], Callable[[ITask], Any]], Callable[[Callable[[Sequence[ITask]], Any]], Callable[[Sequence[ITask]], Any]]]
 ```
 
 Run code before any tasks start, or before each separate task.
@@ -105,19 +105,37 @@ def before_all(tasks):
 
 By default, runs setups in `task` scope.
 
+The `setup` fixture also allows running code after the execution, if it `yield`s the execution to the task(s):
+
+```python
+import time
+from robocorp.tasks import setup
+
+@setup
+def measure_time(task):
+    start = time.time()
+    yield  # Task executes here
+    duration = time.time() - start
+    print(f"Task took {duration} seconds")
+
+@task
+def my_long_task():
+    ...
+```
+
 **Note:** If fixtures are defined in another file, they need to be imported in the main tasks file to be taken into use
 
 ______________________________________________________________________
 
 ## function `teardown`
 
-**Source:** [`_fixtures.py:102`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_fixtures.py#L102)
+**Source:** [`_fixtures.py:148`](https://github.com/robocorp/robo/tree/master/tasks/src/robocorp/tasks/_fixtures.py#L148)
 
 ```python
 teardown(
     *args,
     **kwargs
-) → Union[Callable[[Sequence[ITask]], Any], Callable[[Callable[[Sequence[ITask]], Any]], Callable[[Sequence[ITask]], Any]], Callable[[Callable[[ITask], Any]], Callable[[ITask], Any]]]
+) → Union[Callable[[ITask], Any], Callable[[Callable[[ITask], Any]], Callable[[ITask], Any]], Callable[[Callable[[Sequence[ITask]], Any]], Callable[[Sequence[ITask]], Any]]]
 ```
 
 Run code after tasks have been run, or after each separate task.

--- a/tasks/docs/guides/02-setups-teardowns.md
+++ b/tasks/docs/guides/02-setups-teardowns.md
@@ -25,7 +25,7 @@ A `Task` object is the internal representation of a parsed task in a Python file
 It contains, for instance, the `filename` and `lineno` of the function, but
 also the `status` and optional `message` after it has been executed.
 
-## Example
+## Example usage
 
 ```python
 from robocorp import browser
@@ -50,5 +50,52 @@ def scrape_website():
 
 @task
 def process_data():
+    ...
+```
+
+## Yielding fixtures
+
+Sometimes it's necessary to access a resource created in a `setup` inside a
+`teardown` fixture. In these cases, it's possible to create a `setup` fixture
+that `yield`s.
+
+The library will call the fixture up until the `yield` statement, execute the task,
+and then call the rest of the fixture (in reverse order):
+
+```python
+import time
+from robocorp.tasks import setup
+
+
+@setup
+def measure_time(task):
+    start = time.time()
+    yield  # Task executes here
+    duration = time.time() - start
+    print(f"Task {task.name} took {duration} seconds")
+
+
+@task
+def my_long_task():
+    ...
+```
+
+It's also possible to access the task's result by assigning a value from
+the `yield` statement:
+
+```python
+from robocorp.import browser
+from robocorp.tasks import setup
+
+
+@setup
+def before_and_after(task_before):
+    print(f"Task before running: {task_before}")
+    task_after = yield
+    print(f"Task after running: {task_after}")
+
+
+@task
+def my_task():
     ...
 ```

--- a/tasks/docs/guides/02-setups-teardowns.md
+++ b/tasks/docs/guides/02-setups-teardowns.md
@@ -1,0 +1,54 @@
+# Setups and teardowns
+
+The library contains two fixture methods, `setup` and `teardown`, that can be
+used to call arbitrary functions before and after tasks are run.
+
+The fixtures receive as arguments the tasks objects that the library has parsed
+from the tasks file, which allows fixtures to behave differently based on which
+task is going to be executed or if task failed or passed.
+
+This is useful for having shared initialization or clean-up steps for all tasks,
+or for ensuring that a function is always executed when implementing libraries.
+
+## Scopes
+
+The fixtures can be optionally configured with a `scope` that determines if a
+fixture is run once before or after all tasks, or each time a task will execute.
+Valid values are `task` and `session`.
+
+For `task` scopes (default), the argument is the single task that will or was run.
+For `session` scopes, the argument to the fixture is a list of tasks.
+
+## Task objects
+
+A `Task` object is the internal representation of a parsed task in a Python file.
+It contains, for instance, the `filename` and `lineno` of the function, but
+also the `status` and optional `message` after it has been executed.
+
+## Example
+
+```python
+from robocorp import browser
+from robocorp.tasks import task, teardown
+
+
+@setup(scope="session")
+def configure_browser(tasks):
+    browser.configure(headless=True, screenshot="only-on-failure")
+
+
+@teardown
+def handle_error(task):
+    if task.failed:
+        print(f"Task '{task.name}' failed: {task.message}")
+
+
+@task
+def scrape_website():
+    ...
+
+
+@task
+def process_data():
+    ...
+```

--- a/tasks/docs/guides/02-setups-teardowns.md
+++ b/tasks/docs/guides/02-setups-teardowns.md
@@ -79,23 +79,3 @@ def measure_time(task):
 def my_long_task():
     ...
 ```
-
-It's also possible to access the task's result by assigning a value from
-the `yield` statement:
-
-```python
-from robocorp.import browser
-from robocorp.tasks import setup
-
-
-@setup
-def before_and_after(task_before):
-    print(f"Task before running: {task_before}")
-    task_after = yield
-    print(f"Task after running: {task_after}")
-
-
-@task
-def my_task():
-    ...
-```

--- a/tasks/src/robocorp/tasks/__init__.py
+++ b/tasks/src/robocorp/tasks/__init__.py
@@ -34,6 +34,7 @@ automatically logged is not imported prior the the `cli.main` call.
 from pathlib import Path
 from typing import Optional
 
+from ._fixtures import setup, teardown
 from ._protocols import ITask
 
 __version__ = "2.2.0"
@@ -138,4 +139,13 @@ def get_current_task() -> Optional[ITask]:
     return _task.get_current_task()
 
 
-__all__ = ["task", "session_cache", "task_cache", "get_output_dir", "get_current_task"]
+__all__ = [
+    "task",
+    "setup",
+    "teardown",
+    "session_cache",
+    "task_cache",
+    "get_output_dir",
+    "get_current_task",
+    "ITask",
+]

--- a/tasks/src/robocorp/tasks/_callback.py
+++ b/tasks/src/robocorp/tasks/_callback.py
@@ -14,7 +14,7 @@ class OnExitContextManager:
         self.on_exit()
 
 
-class Callback(object):
+class Callback:
     """
     Note that it's thread safe to register/unregister callbacks while callbacks
     are being notified, but it's not thread-safe to register/unregister at the

--- a/tasks/src/robocorp/tasks/_fixtures.py
+++ b/tasks/src/robocorp/tasks/_fixtures.py
@@ -7,6 +7,11 @@ Decorator = Callable[[T], T]
 
 
 @overload
+def setup(func: ITaskCallback) -> ITaskCallback:
+    ...
+
+
+@overload
 def setup(*, scope: Literal["task"] = "task") -> Decorator[ITaskCallback]:
     ...
 
@@ -16,14 +21,9 @@ def setup(*, scope: Literal["session"]) -> Decorator[ITasksCallback]:
     ...
 
 
-@overload
-def setup(func: ITasksCallback) -> ITasksCallback:
-    ...
-
-
 def setup(
     *args, **kwargs
-) -> Union[ITasksCallback, Decorator[ITasksCallback], Decorator[ITaskCallback]]:
+) -> Union[ITaskCallback, Decorator[ITaskCallback], Decorator[ITasksCallback]]:
     """Run code before any tasks start, or before each separate task.
 
     Receives as an argument the task or tasks that will be run.
@@ -61,8 +61,8 @@ def setup(
     from ._hooks import before_all_tasks_run, before_task_run
 
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
-        func: ITasksCallback = args[0]
-        before_all_tasks_run.register(func)
+        func: ITaskCallback = args[0]
+        before_task_run.register(func)
         return func
 
     scope = kwargs.get("scope", "task")
@@ -85,6 +85,11 @@ def setup(
 
 
 @overload
+def teardown(func: ITaskCallback) -> ITaskCallback:
+    ...
+
+
+@overload
 def teardown(*, scope: Literal["task"] = "task") -> Decorator[ITaskCallback]:
     ...
 
@@ -94,14 +99,9 @@ def teardown(*, scope: Literal["session"]) -> Decorator[ITasksCallback]:
     ...
 
 
-@overload
-def teardown(func: ITasksCallback) -> ITasksCallback:
-    ...
-
-
 def teardown(
     *args, **kwargs
-) -> Union[ITasksCallback, Decorator[ITasksCallback], Decorator[ITaskCallback]]:
+) -> Union[ITaskCallback, Decorator[ITaskCallback], Decorator[ITasksCallback]]:
     """Run code after tasks have been run, or after each separate task.
 
     Receives as an argument the task or tasks that were executed, which
@@ -140,8 +140,8 @@ def teardown(
     from ._hooks import after_all_tasks_run, after_task_run
 
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
-        func: ITasksCallback = args[0]
-        after_all_tasks_run.register(func)
+        func: ITaskCallback = args[0]
+        after_task_run.register(func)
         return func
 
     scope = kwargs.get("scope", "task")

--- a/tasks/src/robocorp/tasks/_fixtures.py
+++ b/tasks/src/robocorp/tasks/_fixtures.py
@@ -96,7 +96,7 @@ def setup(
 
                 def teardown(*args, **kwargs):
                     try:
-                        gen.send(*args, **kwargs)
+                        next(gen)
                     except StopIteration:
                         pass
                     finally:

--- a/tasks/src/robocorp/tasks/_fixtures.py
+++ b/tasks/src/robocorp/tasks/_fixtures.py
@@ -1,0 +1,163 @@
+from typing import Callable, Literal, TypeVar, Union, overload
+
+from ._protocols import ITaskCallback, ITasksCallback
+
+T = TypeVar("T")
+Decorator = Callable[[T], T]
+
+
+@overload
+def setup(*, scope: Literal["task"] = "task") -> Decorator[ITaskCallback]:
+    ...
+
+
+@overload
+def setup(*, scope: Literal["session"]) -> Decorator[ITasksCallback]:
+    ...
+
+
+@overload
+def setup(func: ITasksCallback) -> ITasksCallback:
+    ...
+
+
+def setup(
+    *args, **kwargs
+) -> Union[ITasksCallback, Decorator[ITasksCallback], Decorator[ITaskCallback]]:
+    """Run code before any tasks start, or before each separate task.
+
+    Receives as an argument the task or tasks that will be run.
+
+    Can be used as a decorator without arguments:
+
+    ```python
+    from robocorp.tasks import setup
+
+    @setup
+    def my_fixture(task):
+        print(f"Before task: {task.name}")
+    ```
+
+    Alternatively, can be called with a `scope` argument to decide when
+    the fixture is run:
+
+    ```python
+    from robocorp.tasks import setup
+
+    @setup(scope="task")
+    def before_each(task):
+        print(f"Running task '{task.name}'")
+
+    @setup(scope="session")
+    def before_all(tasks):
+        print(f"Running {len(tasks)} task(s)")
+    ```
+
+    By default, runs setups in `task` scope.
+
+    **Note:** If fixtures are defined in another file, they need to be imported
+     in the main tasks file to be taken into use
+    """
+    from ._hooks import before_all_tasks_run, before_task_run
+
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        func: ITasksCallback = args[0]
+        before_all_tasks_run.register(func)
+        return func
+
+    scope = kwargs.get("scope", "task")
+    if scope == "task":
+
+        def wrapped_task(func: ITaskCallback):
+            before_task_run.register(func)
+            return func
+
+        return wrapped_task
+    elif scope == "session":
+
+        def wrapped_session(func: ITasksCallback):
+            before_all_tasks_run.register(func)
+            return func
+
+        return wrapped_session
+    else:
+        raise ValueError(f"Unknown scope '{scope}', expected 'task' or 'session'")
+
+
+@overload
+def teardown(*, scope: Literal["task"] = "task") -> Decorator[ITaskCallback]:
+    ...
+
+
+@overload
+def teardown(*, scope: Literal["session"]) -> Decorator[ITasksCallback]:
+    ...
+
+
+@overload
+def teardown(func: ITasksCallback) -> ITasksCallback:
+    ...
+
+
+def teardown(
+    *args, **kwargs
+) -> Union[ITasksCallback, Decorator[ITasksCallback], Decorator[ITaskCallback]]:
+    """Run code after tasks have been run, or after each separate task.
+
+    Receives as an argument the task or tasks that were executed, which
+    contain (among other things) the resulting status and possible error message.
+
+    Can be used as a decorator without arguments:
+
+    ```python
+    from robocorp.tasks import teardown
+
+    @teardown
+    def my_fixture(task):
+        print(f"After task: {task.name})
+    ```
+
+    Alternatively, can be called with a `scope` argument to decide when
+    the fixture is run:
+
+    ```python
+    from robocorp.tasks import teardown
+
+    @teardown(scope="task")
+    def after_each(task):
+        print(f"Task '{task.name}' status is '{task.status}'")
+
+    @teardown(scope="session")
+    def after_all(tasks):
+        print(f"Executed {len(tasks)} task(s)")
+    ```
+
+    By default, runs teardowns in `task` scope.
+
+    **Note:** If fixtures are defined in another file, they need to be imported
+     in the main tasks file to be taken into use
+    """
+    from ._hooks import after_all_tasks_run, after_task_run
+
+    if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+        func: ITasksCallback = args[0]
+        after_all_tasks_run.register(func)
+        return func
+
+    scope = kwargs.get("scope", "task")
+    if scope == "task":
+
+        def wrapped_task(func: ITaskCallback):
+            after_task_run.register(func)
+            return func
+
+        return wrapped_task
+    elif scope == "session":
+
+        def wrapped_session(func: ITasksCallback):
+            after_all_tasks_run.register(func)
+            return func
+
+        return wrapped_session
+    else:
+        raise ValueError(f"Unknown scope '{scope}', expected 'task' or 'session'")

--- a/tasks/src/robocorp/tasks/_hooks.py
+++ b/tasks/src/robocorp/tasks/_hooks.py
@@ -15,10 +15,10 @@ on_task_func_found: IOnTaskFuncFoundCallback = Callback(raise_exceptions=True)
 before_collect_tasks: IBeforeCollectTasksCallback = Callback()
 
 # Called as before_all_tasks_run(tasks: List[ITask])
-before_all_tasks_run: IBeforeAllTasksRunCallback = Callback()
+before_all_tasks_run: IBeforeAllTasksRunCallback = Callback(raise_exceptions=True)
 
 # Called as before_task_run(task: ITask)
-before_task_run: IBeforeTaskRunCallback = Callback()
+before_task_run: IBeforeTaskRunCallback = Callback(raise_exceptions=True)
 
 # Called as after_task_run(task: ITask)
 # Note that this one is done in reversed registry order (as is usually

--- a/tasks/src/robocorp/tasks/_hooks.py
+++ b/tasks/src/robocorp/tasks/_hooks.py
@@ -17,7 +17,7 @@ before_collect_tasks: IBeforeCollectTasksCallback = Callback()
 # Called as before_all_tasks_run(tasks: List[ITask])
 before_all_tasks_run: IBeforeAllTasksRunCallback = Callback()
 
-# Called as before_collect_tasks(task: ITask)
+# Called as before_task_run(task: ITask)
 before_task_run: IBeforeTaskRunCallback = Callback()
 
 # Called as after_task_run(task: ITask)

--- a/tasks/src/robocorp/tasks/_task.py
+++ b/tasks/src/robocorp/tasks/_task.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 from robocorp.log import ConsoleMessageKind, console_message
 from robocorp.log.protocols import OptExcInfo
 
-from robocorp.tasks._protocols import ITask, Status
+from robocorp.tasks._protocols import IContext, ITask, Status
 
 
 class Task:
@@ -184,3 +184,8 @@ class Context:
             self._after_task_run
         ):
             yield
+
+    def __typecheckself__(self) -> None:
+        from robocorp.tasks._protocols import check_implements
+
+        _: IContext = check_implements(self)

--- a/tasks/tests/tasks_tests/test_core_log_integration/main_check_lines.py
+++ b/tasks/tests/tasks_tests/test_core_log_integration/main_check_lines.py
@@ -1,5 +1,5 @@
-from robocorp.tasks import task
 from robocorp import log
+from robocorp.tasks import task
 
 
 def another_method_at_line_5(a):

--- a/tasks/tests/tasks_tests/test_fixtures.py
+++ b/tasks/tests/tasks_tests/test_fixtures.py
@@ -165,10 +165,9 @@ def test_setup_generator():
     is_called = False
 
     @tasks_setup
-    def fixture_gen(before):
-        assert before == "before"
-        after = yield
-        assert after == "after"
+    def fixture_gen(task):
+        assert task == "task"
+        yield
         nonlocal is_called
         is_called = True
 
@@ -176,13 +175,13 @@ def test_setup_generator():
     assert len(before_task_run) == 1
     assert len(after_task_run) == 0
 
-    before_task_run("before")
+    before_task_run("task")
 
     assert not is_called
     assert len(before_task_run) == 1
     assert len(after_task_run) == 1
 
-    after_task_run("after")
+    after_task_run("task")
 
     assert is_called
     assert len(before_task_run) == 1

--- a/tasks/tests/tasks_tests/test_fixtures.py
+++ b/tasks/tests/tasks_tests/test_fixtures.py
@@ -1,0 +1,140 @@
+from collections.abc import Iterable
+
+import pytest
+
+from robocorp.tasks import setup as tasks_setup
+from robocorp.tasks import teardown as tasks_teardown
+from robocorp.tasks._hooks import (
+    after_all_tasks_run,
+    after_task_run,
+    before_all_tasks_run,
+    before_task_run,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_callbacks():
+    before_task_run._callbacks = ()
+    before_all_tasks_run._callbacks = ()
+    after_task_run._callbacks = ()
+    after_all_tasks_run._callbacks = ()
+
+
+def test_setup_default():
+    assert len(before_task_run) == 0
+    assert len(before_all_tasks_run) == 0
+
+    is_called = False
+
+    @tasks_setup
+    def fixture(tasks):
+        assert isinstance(tasks, Iterable)
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(before_task_run) == 0
+    assert len(before_all_tasks_run) == 1
+
+    before_all_tasks_run([])
+    assert is_called
+
+
+def test_setup_all():
+    assert len(before_task_run) == 0
+    assert len(before_all_tasks_run) == 0
+
+    is_called = False
+
+    @tasks_setup(scope="session")
+    def fixture(tasks):
+        assert isinstance(tasks, Iterable)
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(before_task_run) == 0
+    assert len(before_all_tasks_run) == 1
+
+    before_all_tasks_run([])
+    assert is_called
+
+
+def test_setup_task():
+    assert len(before_task_run) == 0
+    assert len(before_all_tasks_run) == 0
+
+    is_called = False
+
+    @tasks_setup(scope="task")
+    def fixture(task):
+        assert task == "placeholder"
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(before_task_run) == 1
+    assert len(before_all_tasks_run) == 0
+
+    before_task_run("placeholder")
+    assert is_called
+
+
+def test_teardown_default():
+    assert len(after_task_run) == 0
+    assert len(after_all_tasks_run) == 0
+
+    is_called = False
+
+    @tasks_teardown
+    def fixture(tasks):
+        assert isinstance(tasks, Iterable)
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(after_task_run) == 0
+    assert len(after_all_tasks_run) == 1
+
+    after_all_tasks_run([])
+    assert is_called
+
+
+def test_teardown_all():
+    assert len(after_task_run) == 0
+    assert len(after_all_tasks_run) == 0
+
+    is_called = False
+
+    @tasks_teardown(scope="session")
+    def fixture(tasks):
+        assert isinstance(tasks, Iterable)
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(after_task_run) == 0
+    assert len(after_all_tasks_run) == 1
+
+    after_all_tasks_run([])
+    assert is_called
+
+
+def test_teardown_task():
+    assert len(after_task_run) == 0
+    assert len(after_all_tasks_run) == 0
+
+    is_called = False
+
+    @tasks_teardown(scope="task")
+    def fixture(task):
+        assert task == "placeholder"
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(after_task_run) == 1
+    assert len(after_all_tasks_run) == 0
+
+    after_task_run("placeholder")
+    assert is_called

--- a/tasks/tests/tasks_tests/test_fixtures.py
+++ b/tasks/tests/tasks_tests/test_fixtures.py
@@ -156,3 +156,34 @@ def test_raises():
         before_task_run(None)
 
     after_task_run(None)
+
+
+def test_setup_generator():
+    assert len(before_task_run) == 0
+    assert len(after_task_run) == 0
+
+    is_called = False
+
+    @tasks_setup
+    def fixture_gen(before):
+        assert before == "before"
+        after = yield
+        assert after == "after"
+        nonlocal is_called
+        is_called = True
+
+    assert not is_called
+    assert len(before_task_run) == 1
+    assert len(after_task_run) == 0
+
+    before_task_run("before")
+
+    assert not is_called
+    assert len(before_task_run) == 1
+    assert len(after_task_run) == 1
+
+    after_task_run("after")
+
+    assert is_called
+    assert len(before_task_run) == 1
+    assert len(after_task_run) == 0

--- a/tasks/tests/tasks_tests/test_fixtures.py
+++ b/tasks/tests/tasks_tests/test_fixtures.py
@@ -138,3 +138,21 @@ def test_teardown_task():
 
     after_task_run("placeholder")
     assert is_called
+
+
+def test_raises():
+    @tasks_setup
+    def raises_setup(_):
+        raise RuntimeError("Oopsie")
+
+    @tasks_teardown
+    def raises_teardown(_):
+        raise RuntimeError("Oopsie #2")
+
+    assert len(before_task_run) == 1
+    assert len(after_task_run) == 1
+
+    with pytest.raises(RuntimeError):
+        before_task_run(None)
+
+    after_task_run(None)

--- a/tasks/tests/tasks_tests/test_fixtures.py
+++ b/tasks/tests/tasks_tests/test_fixtures.py
@@ -27,16 +27,16 @@ def test_setup_default():
     is_called = False
 
     @tasks_setup
-    def fixture(tasks):
-        assert isinstance(tasks, Iterable)
+    def fixture(task):
+        assert task == "placeholder"
         nonlocal is_called
         is_called = True
 
     assert not is_called
-    assert len(before_task_run) == 0
-    assert len(before_all_tasks_run) == 1
+    assert len(before_task_run) == 1
+    assert len(before_all_tasks_run) == 0
 
-    before_all_tasks_run([])
+    before_task_run("placeholder")
     assert is_called
 
 
@@ -87,16 +87,16 @@ def test_teardown_default():
     is_called = False
 
     @tasks_teardown
-    def fixture(tasks):
-        assert isinstance(tasks, Iterable)
+    def fixture(task):
+        assert task == "placeholder"
         nonlocal is_called
         is_called = True
 
     assert not is_called
-    assert len(after_task_run) == 0
-    assert len(after_all_tasks_run) == 1
+    assert len(after_task_run) == 1
+    assert len(after_all_tasks_run) == 0
 
-    after_all_tasks_run([])
+    after_task_run("placeholder")
     assert is_called
 
 

--- a/tasks/tests/tasks_tests/test_load_autolog_config.py
+++ b/tasks/tests/tasks_tests/test_load_autolog_config.py
@@ -1,7 +1,10 @@
 def test_load_autolog_config(tmpdir, str_regression) -> None:
     from pathlib import Path
-    from robocorp.log.pyproject_config import read_robocorp_auto_log_config
-    from robocorp.log.pyproject_config import read_pyproject_toml
+
+    from robocorp.log.pyproject_config import (
+        read_pyproject_toml,
+        read_robocorp_auto_log_config,
+    )
 
     target = tmpdir / "pyproject.toml"
     target.write_text(
@@ -30,8 +33,11 @@ log_filter_rules = [
 
 def test_load_autolog_config_exclude_default(tmpdir, str_regression) -> None:
     from pathlib import Path
-    from robocorp.log.pyproject_config import read_pyproject_toml
-    from robocorp.log.pyproject_config import read_robocorp_auto_log_config
+
+    from robocorp.log.pyproject_config import (
+        read_pyproject_toml,
+        read_robocorp_auto_log_config,
+    )
 
     target = tmpdir / "pyproject.toml"
     target.write_text(

--- a/tasks/tests/tasks_tests/test_read_toml_settings.py
+++ b/tasks/tests/tasks_tests/test_read_toml_settings.py
@@ -2,8 +2,7 @@ from pathlib import Path
 
 
 def test_read_toml_settings():
-    from robocorp.log.pyproject_config import PyProjectInfo
-    from robocorp.log.pyproject_config import read_section_from_toml
+    from robocorp.log.pyproject_config import PyProjectInfo, read_section_from_toml
 
     errors_shown = []
 


### PR DESCRIPTION
Needs some documentation, but here's how it currently works:
```python
from robocorp.tasks import task, setup, teardown


@setup
def before_task(task):
    print(f"Running before task: {task.name}")


@setup(scope="session")
def before_all(tasks):
    names = ", ".join(task.name for task in tasks)
    print(f"Running before tasks: {names}")


@teardown
def after_task(task):
    print(f"Running after task: {task.name}")


@teardown(scope="session")
def after_all(task):
    names = ", ".join(task.name for task in tasks)
    print(f"Running after tasks: {names}")


@task
def first():
    print("Doing things")


@task
def second():
    print("Doing other things")
```