### PR TITLE
tasks: allow changing run state from fixtures

### DIFF
--- a/log/src/robocorp/log/__init__.py
+++ b/log/src/robocorp/log/__init__.py
@@ -648,8 +648,8 @@ def end_task(name: str, libname: str, status: str, message: str) -> None:
     Args:
         name: The name of the task.
         libname: The library (module name) where the task is defined.
-        status: The source of the task.
-        message: The line number of the task in the given source.
+        status: The pass/fail status of the task
+        message: The message for a failed task
 
     Note: robocorp-tasks calls this method automatically.
     """

--- a/tasks/docs/CHANGELOG.md
+++ b/tasks/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
     - If not specified the `RC_TEARDOWN_INTERRUPT_TIMEOUT` environment variable may also be used.
 
 - Add support for fixtures with the new `setup` and `teardown` decorators
+- Allow modifying the `status` of tasks in fixtures
 
 ## 2.2.0 - 2023-09-07
 

--- a/tasks/pyproject.toml
+++ b/tasks/pyproject.toml
@@ -24,11 +24,14 @@ robocorp-log = ">=2.4,<3"
 [tool.poetry.group.dev.dependencies]
 robocorp-devutils = {path = "../devutils/", develop = true}
 
-[tool.mypy]
-mypy_path = "src:tests"
-
 [tool.isort]
 profile = "black"
+
+[tool.ruff]
+ignore = ["E501"]
+
+[tool.mypy]
+mypy_path = "src:tests"
 
 [[tool.mypy.overrides]]
 module = "setuptools.*"

--- a/tasks/src/robocorp/tasks/__init__.py
+++ b/tasks/src/robocorp/tasks/__init__.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Optional
 
 from ._fixtures import setup, teardown
-from ._protocols import ITask
+from ._protocols import ITask, Status
 
 __version__ = "2.2.0"
 version_info = [int(x) for x in __version__.split(".")]
@@ -148,4 +148,5 @@ __all__ = [
     "get_output_dir",
     "get_current_task",
     "ITask",
+    "Status",
 ]

--- a/tasks/src/robocorp/tasks/_commands.py
+++ b/tasks/src/robocorp/tasks/_commands.py
@@ -3,7 +3,7 @@ import os
 import sys
 import traceback
 from pathlib import Path
-from typing import List, Optional, Sequence, Union
+from typing import List, Literal, Optional, Sequence, Union
 
 from ._argdispatch import arg_dispatch as _arg_dispatch
 
@@ -232,7 +232,9 @@ def run(
         if task_name:
             run_name += f" - {task_name}"
 
-        run_status: str = Status.PASS
+        # Status string from `log` module
+        # TODO: Replace with enum
+        run_status: Union[Literal["PASS"], Literal["ERROR"]] = "PASS"
         log.start_run(run_name)
 
         try:
@@ -253,7 +255,7 @@ def run(
                         f"Did not find any tasks in: {path}"
                     )
             except Exception as e:
-                run_status = Status.ERROR
+                run_status = "ERROR"
                 setup_message = str(e)
 
                 log.exception()
@@ -276,7 +278,7 @@ def run(
                         task.run()
                         task.status = Status.PASS
                     except Exception as e:
-                        task.status = Status.ERROR
+                        task.status = Status.FAIL
                         task.message = str(e)
                         task.exc_info = sys.exc_info()
                     finally:
@@ -292,7 +294,7 @@ def run(
                             after_task_run(task)
                         set_current_task(None)
                         if task.failed:
-                            run_status = Status.ERROR
+                            run_status = "ERROR"
             finally:
                 log.start_task("Teardown tasks", "teardown", "", 0)
                 try:

--- a/tasks/src/robocorp/tasks/_protocols.py
+++ b/tasks/src/robocorp/tasks/_protocols.py
@@ -1,5 +1,6 @@
 import typing
 from contextlib import contextmanager
+from enum import Enum
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Callable, Iterator, Optional, Sequence, Set, TypeVar, Union
@@ -29,17 +30,12 @@ def check_implements(x: T) -> T:
     return x
 
 
-# Note: this is a bit messy as we're mixing task states with log levels.
-# Note2: This is for the log.html and not really for user APIs.
-class Status:
-    NOT_RUN = "NOT_RUN"  # Initial status for a task which is not run.
-    PASS = "PASS"  # Used for task pass
-    FAIL = "FAIL"  # Used for task failure
+class Status(str, Enum):
+    """Task state"""
 
-    ERROR = "ERROR"  # log.critical
-    INFO = "INFO"  # log.info
-    WARN = "WARN"  # log.warn
-    DEBUG = "DEBUG"  # log.debug
+    NOT_RUN = "NOT_RUN"
+    PASS = "PASS"
+    FAIL = "FAIL"
 
 
 class ITask(typing.Protocol):
@@ -47,7 +43,7 @@ class ITask(typing.Protocol):
     filename: str
     method: typing.Callable
 
-    status: str
+    status: Status
     message: str
     exc_info: Optional[OptExcInfo]
 

--- a/tasks/src/robocorp/tasks/_task.py
+++ b/tasks/src/robocorp/tasks/_task.py
@@ -14,9 +14,9 @@ class Task:
         self.module_name = module.__name__
         self.filename = module.__file__ or "<filename unavailable>"
         self.method = method
-        self.status = Status.NOT_RUN
         self.message = ""
         self.exc_info: Optional[OptExcInfo] = None
+        self._status = Status.NOT_RUN
 
     @property
     def name(self):
@@ -30,8 +30,16 @@ class Task:
         self.method()
 
     @property
+    def status(self) -> Status:
+        return self._status
+
+    @status.setter
+    def status(self, value: Status):
+        self._status = Status(value)
+
+    @property
     def failed(self):
-        return self.status in (Status.ERROR, Status.FAIL)
+        return self._status == Status.FAIL
 
     def __typecheckself__(self) -> None:
         from robocorp.tasks._protocols import check_implements
@@ -150,7 +158,7 @@ class Context:
             msg = f"\n{task.message}"
 
         status_kind = self.KIND_REGULAR
-        if task.status == Status.ERROR:
+        if task.status == Status.FAIL:
             status_kind = self.KIND_ERROR
 
         show = self.show

--- a/tasks/tests/tasks_tests/test_tasks_mutable.py
+++ b/tasks/tests/tasks_tests/test_tasks_mutable.py
@@ -1,0 +1,12 @@
+def test_tasks_mutable(datadir) -> None:
+    from devutils.fixtures import robocorp_tasks_run
+
+    result = robocorp_tasks_run(
+        ["run", "--console-colors=plain"],
+        returncode=0,
+        cwd=str(datadir),
+    )
+
+    stdout = result.stdout.decode("utf-8")
+    assert "Something went wrong" in stdout
+    assert "division by zero" in stdout

--- a/tasks/tests/tasks_tests/test_tasks_mutable/tasks.py
+++ b/tasks/tests/tasks_tests/test_tasks_mutable/tasks.py
@@ -1,0 +1,16 @@
+from robocorp.tasks import task, teardown
+
+
+@teardown
+def make_pass(task):
+    task.status = "PASS"
+
+
+@task
+def raises_error():
+    raise RuntimeError("Something went wrong")
+
+
+@task
+def division_error():
+    _ = 1 / 0


### PR DESCRIPTION
Some minor fixes to `tasks` that makes the final run status (and exit code) depend on the values stored in task objects. Which in turn allows affecting them in the new teardown fixtures.