### PR TITLE
Allow users to configure a persistent_context_directory.

### DIFF
--- a/browser/docs/CHANGELOG.md
+++ b/browser/docs/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - When browsers are installed with playwright additional logging is added.
 - Fixed issue where shutting down playwright could lead to a halting condition inside of asyncio.
+- It's now possible to configure the browser to launch with a persistent context
+  directory (i.e.: `launch_persistent_context`) by specifying a `persistent_context_directory`
+  in the configuration.  
+
+    ```python 
+    from robocorp import browser
+    browser.configure(
+        persistent_context_directory="<path to directory>"
+    )
+    ```
+
 
 ## 2.1.0 - 2023-08-04
 

--- a/browser/docs/README.md
+++ b/browser/docs/README.md
@@ -2,7 +2,7 @@
 
 The `robocorp-browser` is a wrapper for the [Playwright](https://playwright.dev/python/)
 project, with quality-of-life improvements such as automatic lifecycle management
-for Playwright objects.
+for Playwright objects (meant to be used with `robocorp-tasks`).
 
 ## Getting started
 
@@ -54,6 +54,7 @@ def login():
 ## Guides
 
 - [Browser configuration](https://github.com/robocorp/robo/blob/master/browser/docs/guides/00-configuration.md)
+- [Persistent Context](https://github.com/robocorp/robo/blob/master/browser/docs/guides/01-persistent-context.md)
 
 ## API Reference
 

--- a/browser/docs/guides/00-configuration.md
+++ b/browser/docs/guides/00-configuration.md
@@ -31,11 +31,6 @@ Valid values:
 - firefox
 - webkit
 
-### `install`
-
-Install browser before starting. If not defined, download is only
-attempted if the browser fails to launch.
-
 ### `headless`
 
 Run the browser in headless mode.
@@ -55,3 +50,25 @@ Valid values:
 - on
 - off
 - only-on-failure
+
+
+### `install`
+
+Install browser before starting. If not defined, download is only
+attempted if the browser fails to launch.
+
+
+### `isolated`
+
+Used to define where the browser should be downloaded. If `True`, it'll be installed 
+inside the isolated environment. If `False` (default) it'll be installed in a global cache folder.
+
+
+### `persistent_context_directory`
+
+If a persistent context should be used, this should be the directory in which 
+the persistent context should be stored/loaded from (it can be used to store 
+the state of the automation to allow for sessions and cookies to be reused in a
+new automation).
+
+See: [Persistent Context Directory Guide](https://github.com/robocorp/robo/blob/master/browser/docs/guides/01-persistent_context.md)

--- a/browser/docs/guides/01-persistent-context.md
+++ b/browser/docs/guides/01-persistent-context.md
@@ -1,0 +1,45 @@
+# Persistent Context
+
+It's possible to use a persistent context for automating with `robocorp-browser`.
+
+When a persistent context is used, all the information which is obtained
+during the browser interaction (such as cookies, local storage, etc) will
+be saved in a specified directory and when the browser is opened afterwards,
+the same information will be loaded from the given directory.
+
+To use this feature, it's possible to use the `browser.configure` API and
+pass the `persistent_context_directory` (note that this must be called before
+any browser page or context is actually created).
+
+## Example
+
+```python
+from robocorp import browser
+
+browser.configure(
+	persistent_context_directory="./persistent_context",
+)
+
+page = browser.page()
+```
+
+## Caveats
+
+- Note: it's recommended that only a single run uses a given
+  persistent context at a time as the persistent context could include
+  even open pages, which can be potentially troublesome at times. 
+  
+  Sometimes it may be better just to save/restore the cookies (which 
+  can be done using the code below):
+  
+  ```python
+  from robocorp import browser
+  import json
+  
+  cookies = json.dumps(browser.context().cookies())
+  ... # Save to disk (or shared resource such as `Vault`) and later restore with:
+  browser.context().add_cookies(json.loads(cookies))
+  
+- When using the persistent context, the `robocorp.windows.browser()` API will
+  not be available as the browser is always created with a `context`, so,
+  only `robocorp.windows.context()` is applicable.

--- a/browser/src/robocorp/browser/__init__.py
+++ b/browser/src/robocorp/browser/__init__.py
@@ -24,13 +24,38 @@ def configure(**kwargs) -> None:
     initialized will have no effect).
 
     Args:
-        browser_engine: Browser engine which should be used (default: Chromium)
+        browser_engine:
+            Browser engine which should be used
+            default="chromium"
+            choices=["chromium", "chrome", "chrome-beta", "msedge",
+                     "msedge-beta", "msedge-dev", "firefox", "webkit"]
+
+        install:
+            Install browser or not. If not defined, download is only
+            attempted if the browser fails to launch.
+
         headless: If set to False the browser UI will be shown. If set to True
             the browser UI will be kept hidden. If unset or set to None it'll
             show the browser UI only if a debugger is detected.
-        slowmo: Run interactions in slow motion.
+
+        slowmo:
+            Run interactions in slow motion (number in millis).
+
         screenshot: Whether to automatically capture a screenshot after each task.
             Options are `on`, `off`, and `only-on-failure` (default).
+
+        isolated:
+            Used to define where the browser should be downloaded. If `True`,
+            it'll be installed inside the isolated environment. If `False`
+            (default) it'll be installed in a global cache folder.
+
+        persistent_context_directory:
+            If a persistent context should be used, this should be the
+            directory in which the persistent context should be
+            stored/loaded (it can be used to store the state of the
+            automation to allow for sessions and cookies to be reused in a
+            new automation).
+
         viewport_size: Size to be set for the viewport. Specified as tuple(width, height).
 
     Note:
@@ -117,6 +142,13 @@ def browser() -> Browser:
 
         Note that the returned browser must not be closed. It will be
         automatically closed when the task run session finishes.
+
+    Raises:
+        RuntimeError:
+            If `persistent_context_directory` is specified in the configuration
+            and this method is called a RuntimeError is raised (as in this case
+            this API is not applicable as the browser and the context must be
+            created at once and the browser can't be reused for the session).
     """
     from . import _context
 

--- a/browser/src/robocorp/browser/_config.py
+++ b/browser/src/robocorp/browser/_config.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional, Union
 
 from robocorp.tasks import session_cache
@@ -13,6 +14,7 @@ class _BrowserConfig:
         "_slowmo",
         "_screenshot",
         "_isolated",
+        "_persistent_context_directory",
         "__weakref__",
     ]
 
@@ -24,6 +26,7 @@ class _BrowserConfig:
         slowmo: int = 0,
         screenshot: str = "only-on-failure",
         isolated: bool = False,
+        persistent_context_directory: Optional[Union[str, Path]] = None,
     ):
         """
         Args:
@@ -37,8 +40,9 @@ class _BrowserConfig:
                 Install browser or not. If not defined, download is only
                 attempted if the browser fails to launch.
 
-            headless:
-                Run headless or not.
+            headless: If set to False the browser UI will be shown. If set to True
+                the browser UI will be kept hidden. If unset or set to None it'll
+                show the browser UI only if a debugger is detected.
 
             slowmo:
                 Run interactions in slow motion (number in millis).
@@ -49,8 +53,16 @@ class _BrowserConfig:
                 choices=["on", "off", "only-on-failure"]
 
             isolated:
-                Whether to store downloaded browser engines inside the isolated
-                environment, or in a global cache
+                Used to define where the browser should be downloaded. If
+                `True`, it'll be installed inside the isolated environment. If
+                `False` (default) it'll be installed in a global cache folder.
+
+            persistent_context_directory:
+                If a persistent context should be used, this should be the
+                directory in which the persistent context should be
+                stored/loaded from (it can be used to store the state of the
+                automation to allow for sessions and cookies to be reused in a
+                new automation).
         """  # noqa
         self.browser_engine = browser_engine
         self.install = install
@@ -58,6 +70,7 @@ class _BrowserConfig:
         self.slowmo = slowmo
         self.screenshot = screenshot
         self.isolated = isolated
+        self.persistent_context_directory = persistent_context_directory
 
     @property
     def browser_engine(self) -> BrowserEngine:
@@ -112,6 +125,14 @@ class _BrowserConfig:
     def isolated(self, value: bool):
         assert isinstance(value, bool)
         self._isolated = value
+
+    @property
+    def persistent_context_directory(self) -> Optional[Union[str, Path]]:
+        return self._persistent_context_directory
+
+    @persistent_context_directory.setter
+    def persistent_context_directory(self, value: Optional[Union[str, Path]]):
+        self._persistent_context_directory = value
 
 
 @session_cache


### PR DESCRIPTION
In the end the change wasn't as trivial as I expected because `launch_persistent_context` returns a `BrowserContext`, whereas `launch` returns a `Browser` (so, some things didn't map as neatly).