### PR TITLE
Add default request timeout to vault/workitems/storage

### DIFF
--- a/storage/docs/CHANGELOG.md
+++ b/storage/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a default request timeout (60s, override with `RC_API_REQUEST_TIMEOUT`) to
+  Control Room API calls, so a stalled connection raises and retries instead of
+  hanging the run indefinitely.
+
 ## 1.1.0 - 2026-03-12
 
 - Update dependencies

--- a/storage/src/robocorp/storage/_requests.py
+++ b/storage/src/robocorp/storage/_requests.py
@@ -180,7 +180,9 @@ class Requests:
 
         LOGGER.debug("%s %r", verb.__name__.upper(), log_url)
         response = verb(url, *args, headers=headers, **kwargs)
-        LOGGER.debug("%s %r -> %s", verb.__name__.upper(), log_url, response.status_code)
+        LOGGER.debug(
+            "%s %r -> %s", verb.__name__.upper(), log_url, response.status_code
+        )
         handle_error(response)
         return response
 

--- a/storage/src/robocorp/storage/_requests.py
+++ b/storage/src/robocorp/storage/_requests.py
@@ -18,6 +18,10 @@ from tenacity import (
 
 LOGGER = logging.getLogger(__name__)
 DEBUG = bool(os.getenv("RC_DEBUG_API") or os.getenv("RPA_DEBUG_API"))
+# Without an explicit timeout, `requests` will wait indefinitely for a response,
+# so a stalled connection (e.g. dropped by a proxy/load balancer) hangs the task
+# forever instead of raising and letting the `retry` below kick in.
+DEFAULT_TIMEOUT = float(os.getenv("RC_API_REQUEST_TIMEOUT", "60"))
 
 
 def _needs_retry(exc: BaseException) -> bool:
@@ -172,8 +176,11 @@ class Requests:
         if os.getenv("RC_DISABLE_SSL"):
             kwargs["verify"] = False
 
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+
         LOGGER.debug("%s %r", verb.__name__.upper(), log_url)
         response = verb(url, *args, headers=headers, **kwargs)
+        LOGGER.debug("%s %r -> %s", verb.__name__.upper(), log_url, response.status_code)
         handle_error(response)
         return response
 

--- a/storage/tests/test_requests.py
+++ b/storage/tests/test_requests.py
@@ -1,0 +1,54 @@
+import importlib
+from unittest import mock
+
+import pytest
+
+from robocorp.storage import _requests
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_timeout(monkeypatch):
+    """`DEFAULT_TIMEOUT` is computed once at import time, so any test that
+    changes `RC_API_REQUEST_TIMEOUT` must reload the module to pick it up,
+    and this restores the module to its unpatched state afterwards.
+    """
+    yield
+    monkeypatch.delenv("RC_API_REQUEST_TIMEOUT", raising=False)
+    importlib.reload(_requests)
+
+
+class TestRequestTimeout:
+    def test_default_timeout_is_applied(self):
+        with mock.patch("robocorp.storage._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com")
+
+        assert mock_get.call_args.kwargs["timeout"] == _requests.DEFAULT_TIMEOUT
+        assert _requests.DEFAULT_TIMEOUT == 60.0
+
+    def test_env_var_overrides_default_timeout(self, monkeypatch):
+        monkeypatch.setenv("RC_API_REQUEST_TIMEOUT", "5")
+        importlib.reload(_requests)
+
+        with mock.patch("robocorp.storage._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com")
+
+        assert _requests.DEFAULT_TIMEOUT == 5.0
+        assert mock_get.call_args.kwargs["timeout"] == 5.0
+
+    def test_caller_supplied_timeout_is_not_overridden(self):
+        with mock.patch("robocorp.storage._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com", timeout=3.5)
+
+        assert mock_get.call_args.kwargs["timeout"] == 3.5

--- a/vault/docs/CHANGELOG.md
+++ b/vault/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a default request timeout (60s, override with `RC_API_REQUEST_TIMEOUT`) to
+  Control Room API calls, so a stalled connection raises and retries instead of
+  hanging the run indefinitely.
+
 ## 1.4.0 - 2026-03-12
 
 - Update dependencies

--- a/vault/src/robocorp/vault/_requests.py
+++ b/vault/src/robocorp/vault/_requests.py
@@ -180,7 +180,9 @@ class Requests:
 
         LOGGER.debug("%s %r", verb.__name__.upper(), log_url)
         response = verb(url, *args, headers=headers, **kwargs)
-        LOGGER.debug("%s %r -> %s", verb.__name__.upper(), log_url, response.status_code)
+        LOGGER.debug(
+            "%s %r -> %s", verb.__name__.upper(), log_url, response.status_code
+        )
         handle_error(response)
         return response
 

--- a/vault/src/robocorp/vault/_requests.py
+++ b/vault/src/robocorp/vault/_requests.py
@@ -18,6 +18,10 @@ from tenacity import (
 
 LOGGER = logging.getLogger(__name__)
 DEBUG = bool(os.getenv("RC_DEBUG_API") or os.getenv("RPA_DEBUG_API"))
+# Without an explicit timeout, `requests` will wait indefinitely for a response,
+# so a stalled connection (e.g. dropped by a proxy/load balancer) hangs the task
+# forever instead of raising and letting the `retry` below kick in.
+DEFAULT_TIMEOUT = float(os.getenv("RC_API_REQUEST_TIMEOUT", "60"))
 
 
 def _needs_retry(exc: BaseException) -> bool:
@@ -172,8 +176,11 @@ class Requests:
         if os.getenv("RC_DISABLE_SSL"):
             kwargs["verify"] = False
 
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+
         LOGGER.debug("%s %r", verb.__name__.upper(), log_url)
         response = verb(url, *args, headers=headers, **kwargs)
+        LOGGER.debug("%s %r -> %s", verb.__name__.upper(), log_url, response.status_code)
         handle_error(response)
         return response
 

--- a/vault/tests/robocorp_vault_tests/test_requests.py
+++ b/vault/tests/robocorp_vault_tests/test_requests.py
@@ -1,0 +1,54 @@
+import importlib
+
+import mock
+import pytest
+
+from robocorp.vault import _requests
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_timeout(monkeypatch):
+    """`DEFAULT_TIMEOUT` is computed once at import time, so any test that
+    changes `RC_API_REQUEST_TIMEOUT` must reload the module to pick it up,
+    and this restores the module to its unpatched state afterwards.
+    """
+    yield
+    monkeypatch.delenv("RC_API_REQUEST_TIMEOUT", raising=False)
+    importlib.reload(_requests)
+
+
+class TestRequestTimeout:
+    def test_default_timeout_is_applied(self):
+        with mock.patch("robocorp.vault._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com")
+
+        assert mock_get.call_args.kwargs["timeout"] == _requests.DEFAULT_TIMEOUT
+        assert _requests.DEFAULT_TIMEOUT == 60.0
+
+    def test_env_var_overrides_default_timeout(self, monkeypatch):
+        monkeypatch.setenv("RC_API_REQUEST_TIMEOUT", "5")
+        importlib.reload(_requests)
+
+        with mock.patch("robocorp.vault._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com")
+
+        assert _requests.DEFAULT_TIMEOUT == 5.0
+        assert mock_get.call_args.kwargs["timeout"] == 5.0
+
+    def test_caller_supplied_timeout_is_not_overridden(self):
+        with mock.patch("robocorp.vault._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com", timeout=3.5)
+
+        assert mock_get.call_args.kwargs["timeout"] == 3.5

--- a/workitems/docs/CHANGELOG.md
+++ b/workitems/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a default request timeout (60s, override with `RC_API_REQUEST_TIMEOUT`) to
+  Control Room API calls, so a stalled connection raises and retries instead of
+  hanging the run indefinitely.
+
 ## 1.5.0 - 2026-03-12
 
 - Update dependencies

--- a/workitems/src/robocorp/workitems/_requests.py
+++ b/workitems/src/robocorp/workitems/_requests.py
@@ -180,7 +180,9 @@ class Requests:
 
         LOGGER.debug("%s %r", verb.__name__.upper(), log_url)
         response = verb(url, *args, headers=headers, **kwargs)
-        LOGGER.debug("%s %r -> %s", verb.__name__.upper(), log_url, response.status_code)
+        LOGGER.debug(
+            "%s %r -> %s", verb.__name__.upper(), log_url, response.status_code
+        )
         handle_error(response)
         return response
 

--- a/workitems/src/robocorp/workitems/_requests.py
+++ b/workitems/src/robocorp/workitems/_requests.py
@@ -18,6 +18,10 @@ from tenacity import (
 
 LOGGER = logging.getLogger(__name__)
 DEBUG = bool(os.getenv("RC_DEBUG_API") or os.getenv("RPA_DEBUG_API"))
+# Without an explicit timeout, `requests` will wait indefinitely for a response,
+# so a stalled connection (e.g. dropped by a proxy/load balancer) hangs the task
+# forever instead of raising and letting the `retry` below kick in.
+DEFAULT_TIMEOUT = float(os.getenv("RC_API_REQUEST_TIMEOUT", "60"))
 
 
 def _needs_retry(exc: BaseException) -> bool:
@@ -172,8 +176,11 @@ class Requests:
         if os.getenv("RC_DISABLE_SSL"):
             kwargs["verify"] = False
 
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+
         LOGGER.debug("%s %r", verb.__name__.upper(), log_url)
         response = verb(url, *args, headers=headers, **kwargs)
+        LOGGER.debug("%s %r -> %s", verb.__name__.upper(), log_url, response.status_code)
         handle_error(response)
         return response
 

--- a/workitems/tests/workitems_tests/test_adapters.py
+++ b/workitems/tests/workitems_tests/test_adapters.py
@@ -11,7 +11,7 @@ import pytest
 from requests import HTTPError as _HTTPError
 
 from robocorp.workitems._adapters import FileAdapter, RobocorpAdapter
-from robocorp.workitems._requests import DEBUG, HTTPError
+from robocorp.workitems._requests import DEBUG, DEFAULT_TIMEOUT, HTTPError
 from robocorp.workitems._types import State
 
 ITEMS_JSON = [{"payload": {"a-key": "a-value"}, "files": {"a-file": "file.txt"}}]
@@ -225,7 +225,9 @@ class TestRobocorpAdapter:
         assert reserved_item_id == "44"
 
         url = "https://api.process.com/process-v1/workspaces/1/processes/5/runs/2/robotRuns/3/reserve-next-work-item"
-        self.mock_post.assert_called_once_with(url, headers=self.HEADERS_PROCESS)
+        self.mock_post.assert_called_once_with(
+            url, headers=self.HEADERS_PROCESS, timeout=DEFAULT_TIMEOUT
+        )
 
     @pytest.mark.parametrize(
         "exception",
@@ -249,7 +251,7 @@ class TestRobocorpAdapter:
                 key: value for (key, value) in exception.items() if value
             }
         self.mock_post.assert_called_once_with(
-            url, headers=self.HEADERS_PROCESS, json=body
+            url, headers=self.HEADERS_PROCESS, json=body, timeout=DEFAULT_TIMEOUT
         )
 
     def test_load_payload(self, adapter):
@@ -272,7 +274,7 @@ class TestRobocorpAdapter:
 
         url = f"https://api.workitem.com/json-v1/workspaces/1/workitems/{item_id}/data"
         self.mock_put.assert_called_once_with(
-            url, headers=self.HEADERS_WORKITEM, json=payload
+            url, headers=self.HEADERS_WORKITEM, json=payload, timeout=DEFAULT_TIMEOUT
         )
 
     def test_remove_file(self, adapter):
@@ -285,7 +287,9 @@ class TestRobocorpAdapter:
         adapter.remove_file(item_id, name)
 
         url = f"https://api.workitem.com/json-v1/workspaces/1/workitems/{item_id}/files/{file_id}"
-        self.mock_delete.assert_called_once_with(url, headers=self.HEADERS_WORKITEM)
+        self.mock_delete.assert_called_once_with(
+            url, headers=self.HEADERS_WORKITEM, timeout=DEFAULT_TIMEOUT
+        )
 
     def test_list_files(self, adapter):
         expected_files = ["just.py", "mark.robot", "it.txt"]

--- a/workitems/tests/workitems_tests/test_requests.py
+++ b/workitems/tests/workitems_tests/test_requests.py
@@ -1,0 +1,54 @@
+import importlib
+from unittest import mock
+
+import pytest
+
+from robocorp.workitems import _requests
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_timeout(monkeypatch):
+    """`DEFAULT_TIMEOUT` is computed once at import time, so any test that
+    changes `RC_API_REQUEST_TIMEOUT` must reload the module to pick it up,
+    and this restores the module to its unpatched state afterwards.
+    """
+    yield
+    monkeypatch.delenv("RC_API_REQUEST_TIMEOUT", raising=False)
+    importlib.reload(_requests)
+
+
+class TestRequestTimeout:
+    def test_default_timeout_is_applied(self):
+        with mock.patch("robocorp.workitems._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com")
+
+        assert mock_get.call_args.kwargs["timeout"] == _requests.DEFAULT_TIMEOUT
+        assert _requests.DEFAULT_TIMEOUT == 60.0
+
+    def test_env_var_overrides_default_timeout(self, monkeypatch):
+        monkeypatch.setenv("RC_API_REQUEST_TIMEOUT", "5")
+        importlib.reload(_requests)
+
+        with mock.patch("robocorp.workitems._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com")
+
+        assert _requests.DEFAULT_TIMEOUT == 5.0
+        assert mock_get.call_args.kwargs["timeout"] == 5.0
+
+    def test_caller_supplied_timeout_is_not_overridden(self):
+        with mock.patch("robocorp.workitems._requests.requests.get") as mock_get:
+            mock_get.__name__ = "get"
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.ok = True
+
+            _requests.Requests().get("https://example.com", timeout=3.5)
+
+        assert mock_get.call_args.kwargs["timeout"] == 3.5


### PR DESCRIPTION
## Summary
- Adds a default 60s timeout (override via `RC_API_REQUEST_TIMEOUT`) to the shared `_requests.py` HTTP wrapper duplicated across `vault`, `workitems`, and `storage`, so a stalled Control Room connection raises and lets the existing tenacity retry take over instead of hanging the run indefinitely.
- Logs the response status after each call for easier debugging of future hangs.
- Fixes a `ruff format` line-length violation introduced by the debug-log line.
- Adds unit tests per package (`test_requests.py`) that exercise the `Requests` wrapper directly: default timeout applied, `RC_API_REQUEST_TIMEOUT` override, and caller-supplied `timeout=` is respected and not clobbered.
- Fixes `workitems` adapter tests whose mocked call assertions didn't account for the new `timeout` kwarg.

## Test plan
- [x] `inv check-all` (lint + typecheck + test + docs --check) passes in `vault`, `workitems`, and `storage`
- [x] New `test_requests.py` in each package verifies default/override/caller-supplied timeout behavior
- [x] Verified `_requests.py` is still byte-identical across all three packages